### PR TITLE
#533: Update the Elasticsearch client to version 8.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 
         <!-- Dependency versions -->
         <lombok.version>1.18.26</lombok.version>
+        <elasticsearch.version>8.7.1</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -80,7 +81,7 @@
         <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
-            <version>7.17.9</version>
+            <version>${elasticsearch.version}</version>
         </dependency>
 
         <!-- Logging -->
@@ -339,9 +340,13 @@
                 <artifactId>elasticsearch-maven-plugin</artifactId>
                 <version>6.26</version>
                 <configuration>
-                    <version>7.17.1</version>
+                    <version>${elasticsearch.version}</version>
                     <httpPort>9250</httpPort>
                     <transportPort>9350</transportPort>
+                    <autoCreateIndex>false</autoCreateIndex>
+                    <environmentVariables>
+                        <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
+                    </environmentVariables>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/eu/cessda/pasc/oci/exception/UnsupportedXMLNamespaceException.java
+++ b/src/main/java/eu/cessda/pasc/oci/exception/UnsupportedXMLNamespaceException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package eu.cessda.pasc.oci.exception;
 
 import org.jdom2.Namespace;

--- a/src/main/java/eu/cessda/pasc/oci/exception/UnsupportedXMLNamespaceException.java
+++ b/src/main/java/eu/cessda/pasc/oci/exception/UnsupportedXMLNamespaceException.java
@@ -1,0 +1,28 @@
+package eu.cessda.pasc.oci.exception;
+
+import org.jdom2.Namespace;
+
+import java.io.Serial;
+
+/**
+ * Thrown when attempting to parse a DDI document with an unsupported XML namespace.
+ */
+public class UnsupportedXMLNamespaceException extends IllegalArgumentException {
+    @Serial
+    private static final long serialVersionUID = -5524959625579025110L;
+
+    private final Namespace namespace;
+
+    /**
+     * Constructs an UnsupportedXMLNamespaceException with the specified namespace.
+     * @param namespace the namespace.
+     */
+    public UnsupportedXMLNamespaceException(Namespace namespace) {
+        super("XML namespace \"" + namespace.getURI() + "\" not supported");
+        this.namespace = namespace;
+    }
+
+    public Namespace getNamespace() {
+        return namespace;
+    }
+}

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -15,6 +15,7 @@
  */
 package eu.cessda.pasc.oci.parser;
 
+import eu.cessda.pasc.oci.exception.UnsupportedXMLNamespaceException;
 import lombok.*;
 import org.jdom2.Namespace;
 
@@ -156,11 +157,13 @@ public final class XPaths implements Serializable {
 
     /**
      * Get the XPaths for a given XML namespace
+     *
+     * @throws UnsupportedXMLNamespaceException if the namespace is unsupported
      */
     public static XPaths getXPaths(Namespace namespace) {
         var xpaths = XPATH_MAP.get(namespace);
         if (xpaths == null) {
-            throw new IllegalArgumentException("XML namespace \"" + namespace.getURI() + "\" not supported");
+            throw new UnsupportedXMLNamespaceException(namespace);
         }
         return xpaths;
     }

--- a/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
@@ -16,6 +16,7 @@
 package eu.cessda.pasc.oci.elasticsearch;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.FieldSort;
 import co.elastic.clients.elasticsearch._types.SortOptions;
 import co.elastic.clients.elasticsearch._types.SortOrder;
@@ -89,7 +90,11 @@ public class ESIngestServiceTestIT {
      */
     @After
     public void tearDown() throws IOException {
-        elasticsearchClient.indices().delete(DeleteIndexRequest.of(d -> d.index("_all")));
+        try {
+            elasticsearchClient.indices().delete(DeleteIndexRequest.of(d -> d.index(INDEX_NAME)));
+        } catch (ElasticsearchException e) {
+            // ignore all Elasticsearch Exceptions
+        }
     }
 
     @Test


### PR DESCRIPTION
This replaces the deprecated Elasticsearch `RestHighLevelClient` with the new `ElasticsearchClient`, and updates it to version 8.7.1.

This resolves cessda/cessda.cdc.versions#533.