### PR TITLE
RenameSuggestion

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -255,7 +255,7 @@ public class CMMStudyMapper {
             parTitles.forEach(titles::putIfAbsent);  // parTitl lang must not be same as or override titl lang
 
             // Remove return characters from the values
-            titles.replaceAll((key, value) -> ParsingStrategies.cleanCharacterReturns(value));
+            titles.replaceAll((key, value) -> ParsingStrategies.cleanReturnCharacters(value));
         }
         return titles;
     }

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -54,7 +54,7 @@ class ParsingStrategies {
      */
     static Optional<Country> countryStrategy(Element element) {
         var builder = Country.builder();
-        builder.elementText(cleanCharacterReturns(element.getText()));
+        builder.elementText(cleanReturnCharacters(element.getText()));
         getAttributeValue(element, ABBR_ATTR).ifPresent(builder::isoCode);
         return Optional.of(builder.build());
     }
@@ -112,7 +112,7 @@ class ParsingStrategies {
     static Publisher publisherStrategy(Element element) {
         return Publisher.builder()
             .abbreviation(getAttributeValue(element, ABBR_ATTR).orElse(PUBLISHER_NOT_AVAIL))
-            .name(cleanCharacterReturns(element.getText()))
+            .name(cleanReturnCharacters(element.getText()))
             .build();
     }
 
@@ -120,7 +120,7 @@ class ParsingStrategies {
         var conceptVal = ofNullable(element.getChild(CONCEPT_EL, namespace)).orElse(new Element(EMPTY_EL));
 
         var builder = TermVocabAttributes.builder();
-        builder.term(cleanCharacterReturns(element.getText()));
+        builder.term(cleanReturnCharacters(element.getText()));
         if (hasControlledValue) {
             builder.vocab(getAttributeValue(conceptVal, VOCAB_ATTR).orElse(""))
                 .vocabUri(getAttributeValue(conceptVal, VOCAB_URI_ATTR).orElse(""))
@@ -287,7 +287,7 @@ class ParsingStrategies {
     /**
      * Remove return characters (i.e. {@code \n}) from the string.
      */
-    static String cleanCharacterReturns(String candidate) {
+    static String cleanReturnCharacters(String candidate) {
         return candidate.replace("\n", "").trim();
     }
 


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We find a non-descriptive method name in your repository:
```java
/* Non-descriptive Method Name in src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java */
static String cleanCharacterReturns(String candidate) {
        return candidate.replace("\n", "").trim();
    }

```
We considered "cleanCharacterReturns" as non-descriptive because it ends with "return", which may be misleading because "return" is a verb in most cases (although in this case, it is a noun representing a CR symbol). We proposed renaming the method name to "cleanReturnCharacters". Consequently, when we look at this method name, we will consider "return" as a noun logically because it follows with "characters".

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.