### PR TITLE
622 add XPaths for DDI 3.x documents

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -91,34 +91,177 @@ public final class XPaths implements Serializable {
     }
 
     /**
+     * XPaths needed to extract metadata from DDI 3.3 documents.
+     */
+    public static final XPaths DDI_3_3_XPATHS = XPaths.builder()
+        .namespace(Namespace.getNamespace("ddi", "ddi:instance:3_3"))
+        // Abstract
+        .abstractXPath("//ddi:DDIInstance/s:StudyUnit/r:Abstract/r:Content")
+        // Study title
+        .titleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
+        // Study title (in additional languages)
+        .parTitleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
+        // 'Access study' link (when @typeOfUserID attribute is "URLServiceProvider")
+        .studyURLDocDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
+        .studyURLStudyDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // Study number/PID (when @typeOfUserID attribute is "StudyNumber")
+        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // Study number/PID 
+        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
+        // Creator/PI
+        .creatorsXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Creator/r:CreatorReference")
+        // Terms of data access
+        .dataAccessUrlXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
+        // Terms of data access
+        .dataRestrctnXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
+        // Data collection period
+        .dataCollectionPeriodsXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:CollectionSituation/r:Description/r:Content")
+        // Publication year
+        .yearOfPubXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:PublicationDate/r:SimpleDate")
+        // Topics
+        .classificationsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Subject")
+        // Keywords
+        .keywordsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Keyword")
+        // Time dimension
+        .typeOfTimeMethodXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:TimeMethod/r:Description/r:Content")
+        // Country
+        .studyAreaCountriesXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:SpatialCoverage/r:Description/r:Content")
+        // Analysis unit (descriptive)
+        .unitTypeXPath("//ddi:DDIInstance/s:StudyUnit/r:AnalysisUnitsCovered")
+        // Publisher
+        .publisherXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference")
+        // Publisher Reference (Institution)
+        .distributorXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference/r:URN")
+        // Language of data file(s)
+        .fileTxtLanguagesXPath("//ddi:DDIInstance/r:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Language")
+        // Language-specific name of file
+        .filenameLanguagesXPath("//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Title/r:String")
+        // Sampling procedure (descriptive)
+        .samplingXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:SamplingProcedure/r:Description/r:Content")
+        // Data collection mode (descriptive)
+        .typeOfModeOfCollectionXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:ModeOfCollection/r:Description/r:Content")
+        // Related publication (PID)
+        .relatedPublicationsXPath("//ddi:DDIInstance/s:StudyUnit/r:OtherMaterial/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
+        // Study description language
+        .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
+        // Description of population
+        .universeXPath("//ddi:DDIInstance/s:StudyUnit/c:ConceptualComponent/c:UniverseScheme/")
+        .build();
+
+    /**
+     * XPaths needed to extract metadata from DDI 3.2 documents.
+     */
+    public static final XPaths DDI_3_2_XPATHS = XPaths.builder()
+        .namespace(Namespace.getNamespace("ddi", "ddi:instance:3_2"))
+        // Abstract
+        .abstractXPath("//ddi:DDIInstance/s:StudyUnit/r:Abstract/r:Content")
+        // Study title
+        .titleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
+        // Study title (in additional languages)
+        .parTitleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
+        // 'Access study' link (when @typeOfUserID attribute is "URLServiceProvider")
+        .studyURLDocDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
+        .studyURLStudyDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // Study number/PID (when @typeOfUserID attribute is "StudyNumber")
+        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // Study number/PID 
+        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
+        // Creator/PI
+        .creatorsXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Creator/r:CreatorReference")
+        // Terms of data access
+        .dataAccessUrlXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
+        // Terms of data access
+        .dataRestrctnXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
+        // Data collection period
+        .dataCollectionPeriodsXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:CollectionSituation/r:Description/r:Content")
+        // Publication year
+        .yearOfPubXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:PublicationDate/r:SimpleDate")
+        // Topics
+        .classificationsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Subject")
+        // Keywords
+        .keywordsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Keyword")
+        // Time dimension
+        .typeOfTimeMethodXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:TimeMethod/r:Description/r:Content")
+        // Country
+        .studyAreaCountriesXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:SpatialCoverage/r:Description/r:Content")
+        // Analysis unit
+        .unitTypeXPath("//ddi:DDIInstance/s:StudyUnit/r:AnalysisUnitsCovered")
+        // Publisher
+        .publisherXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference")
+        // Publisher Reference (Institution)
+        .distributorXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference/r:URN")
+        // Language of data file(s)
+        .fileTxtLanguagesXPath("//ddi:DDIInstance/r:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Language")
+        // Language-specific name of file
+        .filenameLanguagesXPath("//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Title/r:String")
+        // Sampling procedure
+        .samplingXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:SamplingProcedure/r:Description/r:Content")
+        // Data collection mode
+        .typeOfModeOfCollectionXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:ModeOfCollection/r:Description/r:Content")
+        // PID of Related publication
+        .relatedPublicationsXPath("//ddi:DDIInstance/s:StudyUnit/r:OtherMaterial/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
+        // Study description language
+        .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
+        // Description of population
+        .universeXPath("//ddi:DDIInstance/s:StudyUnit/c:ConceptualComponent/c:UniverseScheme/")
+        .build();
+
+    /**
      * XPaths needed to extract metadata from DDI 2.5 documents.
      */
     public static final XPaths DDI_2_5_XPATHS = XPaths.builder()
         .namespace(Namespace.getNamespace("ddi", "ddi:codebook:2_5"))
+        // Abstract
         .abstractXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract")
+        // Study title
         .titleXPath("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl")
+        // Study title (in additional languages)
         .parTitleXPath("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl")
+        // 'Access study' link
         .studyURLDocDscrXPath("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:holdings")
+        // URL of the study description page at the SP website
         .studyURLStudyDscrXPath("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings")
+        // Study number/PID
         .pidStudyXPath("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo")
+        // Creator
         .creatorsXPath("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty")
+        // Terms of data access
         .dataAccessUrlXPath("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:specPerm")
+        // Terms of data access
         .dataRestrctnXPath("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn")
+        // Data collection period
         .dataCollectionPeriodsXPath("//ddi:codeBook//ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate")
+        // Publication year
         .yearOfPubXPath("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate[1]/@date")
+        // Topics
         .classificationsXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas")
+        // Keywords
         .keywordsXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword")
+        // Time dimension
         .typeOfTimeMethodXPath("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth")
+        // Country
         .studyAreaCountriesXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation")
+        // Analysis unit
         .unitTypeXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit")
+        // Publisher name/Contributor
         .publisherXPath("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:prodStmt/ddi:producer")
+        // Publisher
         .distributorXPath("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr")
+        // Language of data file(s)
         .fileTxtLanguagesXPath("//ddi:codeBook/ddi:fileDscr/ddi:fileTxt/@xml:lang")
+        // Language-specific name of file
         .filenameLanguagesXPath("//ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang")
+        // Sampling procedure
         .samplingXPath("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc")
+        // Data collection mode
         .typeOfModeOfCollectionXPath("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode")
+        // Related publication
         .relatedPublicationsXPath("//ddi:codeBook/ddi:stdyDscr/ddi:othrStdyMat/ddi:relPubl")
+        // Study description language
         .recordDefaultLanguage("//ddi:codeBook/@xml:lang")
+        // Description of population
         .universeXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:universe")
         .build();
 
@@ -158,6 +301,8 @@ public final class XPaths implements Serializable {
      * Mapping of XML namespaces to XPaths
      */
     private static final Map<Namespace, XPaths> XPATH_MAP = Map.ofEntries(
+        Map.entry(DDI_3_3_XPATHS.getNamespace(), DDI_3_3_XPATHS),
+        Map.entry(DDI_3_2_XPATHS.getNamespace(), DDI_3_2_XPATHS),
         Map.entry(DDI_2_5_XPATHS.getNamespace(), DDI_2_5_XPATHS),
         Map.entry(NESSTAR_XPATHS.getNamespace(), NESSTAR_XPATHS)
     );


### PR DESCRIPTION
Added XPaths for DDI 3.2 and 3.2. Currently identical, but having both allows flexibility if needed, in regard of fragments etc.

This closes https://github.com/cessda/cessda.cdc.versions/issues/622