### PR TITLE
Implement basic parsing of DDI 3.x documents

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
                 withMaven {
                     sh "./mvnw jib:build -Dimage=${image_tag}"
                 }
-                sh "gcloud container images add-tag ${image_tag} ${DOCKER_ARTIFACT_REGISTRY}/${product_name}-${module_name}:${env.BRANCH_NAME}-latest"
+                sh "gcloud artifacts docker tags add ${image_tag} ${DOCKER_ARTIFACT_REGISTRY}/${product_name}-${module_name}:${env.BRANCH_NAME}-latest"
             }
             when { branch 'main' }
 		}

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -37,7 +37,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static eu.cessda.pasc.oci.parser.OaiPmhConstants.*;
-import static eu.cessda.pasc.oci.parser.ParsingStrategies.*;
+import static eu.cessda.pasc.oci.parser.ParsingStrategies.termVocabAttributeStrategy;
+import static eu.cessda.pasc.oci.parser.ParsingStrategies.uriStrategy;
 
 /**
  * Responsible for Mapping oai-pmh fields to a CMMStudy
@@ -98,7 +99,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<Pid>> parsePidStudies(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getPidStudyXPath(), xPaths.getNamespace(), ParsingStrategies::pidStrategy);
+            defaultLangIsoCode, document, xPaths.getPidStudyXPath(), ParsingStrategies::pidStrategy, xPaths.getNamespace());
     }
 
     /**
@@ -126,7 +127,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<String>> parseCreator(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getCreatorsXPath(), xPaths.getNamespace(), ParsingStrategies::creatorStrategy
+            defaultLangIsoCode, document, xPaths.getCreatorsXPath(), ParsingStrategies::creatorStrategy, xPaths.getNamespace()
         );
     }
 
@@ -137,8 +138,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<TermVocabAttributes>> parseClassifications(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getClassificationsXPath(), xPaths.getNamespace(),
-            element -> termVocabAttributeStrategy(element, xPaths.getNamespace(), false)
+            defaultLangIsoCode, doc, xPaths.getClassificationsXPath(), element -> termVocabAttributeStrategy(element, false), xPaths.getNamespace()
         );
     }
 
@@ -149,8 +149,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<TermVocabAttributes>> parseKeywords(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getKeywordsXPath(), xPaths.getNamespace(),
-            element -> termVocabAttributeStrategy(element, xPaths.getNamespace(), false)
+            defaultLangIsoCode, doc, xPaths.getKeywordsXPath(), element -> termVocabAttributeStrategy(element, false), xPaths.getNamespace()
         );
     }
 
@@ -162,8 +161,7 @@ public class CMMStudyMapper {
     Map<String, List<TermVocabAttributes>> parseTypeOfTimeMethod(Document doc, XPaths xPaths, String defaultLangIsoCode) {
 
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getTypeOfTimeMethodXPath(), xPaths.getNamespace(),
-            element -> termVocabAttributeStrategy(element, xPaths.getNamespace(),true)
+            defaultLangIsoCode, doc, xPaths.getTypeOfTimeMethodXPath(), element -> termVocabAttributeStrategy(element, true), xPaths.getNamespace()
         );
     }
 
@@ -174,8 +172,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<TermVocabAttributes>> parseTypeOfModeOfCollection(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getTypeOfModeOfCollectionXPath(), xPaths.getNamespace(),
-            element -> termVocabAttributeStrategy(element, xPaths.getNamespace(), true)
+            defaultLangIsoCode, doc, xPaths.getTypeOfModeOfCollectionXPath(), element -> termVocabAttributeStrategy(element, true), xPaths.getNamespace()
         );
     }
 
@@ -186,8 +183,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<TermVocabAttributes>> parseUnitTypes(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getUnitTypeXPath(), xPaths.getNamespace(),
-            element -> termVocabAttributeStrategy(element, xPaths.getNamespace(), true)
+            defaultLangIsoCode, document, xPaths.getUnitTypeXPath(), element -> termVocabAttributeStrategy(element, true), xPaths.getNamespace()
         );
     }
 
@@ -198,8 +194,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<VocabAttributes>> parseTypeOfSamplingProcedure(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getSamplingXPath(), xPaths.getNamespace(),
-            element -> samplingTermVocabAttributeStrategy(element, xPaths.getNamespace())
+            defaultLangIsoCode, doc, xPaths.getSamplingXPath(), ParsingStrategies::samplingTermVocabAttributeStrategy, xPaths.getNamespace()
         );
     }
 
@@ -210,8 +205,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<Country>> parseStudyAreaCountries(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getStudyAreaCountriesXPath(), xPaths.getNamespace(),
-            ParsingStrategies::countryStrategy
+            defaultLangIsoCode, document, xPaths.getStudyAreaCountriesXPath(), ParsingStrategies::countryStrategy, xPaths.getNamespace()
         );
     }
 
@@ -223,13 +217,17 @@ public class CMMStudyMapper {
      */
     Map<String, Publisher> parsePublisher(Document document, XPaths xPaths, String defaultLang) {
         var producerPathMap = docElementParser.extractMetadataObjectForEachLang(
-            defaultLang, document, xPaths.getPublisherXPath(), xPaths.getNamespace(),
-            ParsingStrategies::publisherStrategy
+            defaultLang, document, xPaths.getPublisherXPath(), ParsingStrategies::publisherStrategy, xPaths.getNamespace()
         );
-        var distrPathMap = docElementParser.extractMetadataObjectForEachLang(
-            defaultLang, document, xPaths.getDistributorXPath(), xPaths.getNamespace(),
-            ParsingStrategies::publisherStrategy
-        );
+
+        Map<String, Publisher> distrPathMap;
+        if (xPaths.getDistributorXPath() != null) {
+            distrPathMap = docElementParser.extractMetadataObjectForEachLang(
+                defaultLang, document, xPaths.getDistributorXPath(), ParsingStrategies::publisherStrategy, xPaths.getNamespace()
+            );
+        } else {
+            distrPathMap = Collections.emptyMap();
+        }
 
         distrPathMap.forEach((k, v) -> producerPathMap.merge(k, v, (docDscrValue, stdyDscrValue) -> docDscrValue));
         return producerPathMap;
@@ -250,7 +248,7 @@ public class CMMStudyMapper {
         Map<String, String> titles = parseLanguageContentOfElement(document, langCode, xPaths.getTitleXPath(), false, xPaths.getNamespace());
 
         // https://github.com/cessda/cessda.cdc.versions/issues/135
-        if (!titles.isEmpty()) {
+        if (xPaths.getParTitleXPath() != null && !titles.isEmpty()) {
             Map<String, String> parTitles = parseLanguageContentOfElement(document, langCode, xPaths.getParTitleXPath(), false, xPaths.getNamespace());
             parTitles.forEach(titles::putIfAbsent);  // parTitl lang must not be same as or override titl lang
 
@@ -306,8 +304,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<String>> parseSamplingProcedureFreeTexts(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getSamplingXPath(), xPaths.getNamespace(),
-            ParsingStrategies::nullableElementValueStrategy
+            defaultLangIsoCode, doc, xPaths.getSamplingXPath(), ParsingStrategies::nullableElementValueStrategy, xPaths.getNamespace()
         );
     }
 
@@ -318,8 +315,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<String>> parseDataAccessFreeText(Document doc, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, doc, xPaths.getDataRestrctnXPath(), xPaths.getNamespace(),
-            ParsingStrategies::nullableElementValueStrategy
+            defaultLangIsoCode, doc, xPaths.getDataRestrctnXPath(), ParsingStrategies::nullableElementValueStrategy, xPaths.getNamespace()
         );
     }
 
@@ -330,8 +326,7 @@ public class CMMStudyMapper {
      */
     Map<String, List<DataCollectionFreeText>> parseDataCollectionFreeTexts(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getDataCollectionPeriodsXPath(), xPaths.getNamespace(),
-            ParsingStrategies::dataCollFreeTextStrategy
+            defaultLangIsoCode, document, xPaths.getDataCollectionPeriodsXPath(), ParsingStrategies::dataCollFreeTextStrategy, xPaths.getNamespace()
         );
     }
 
@@ -414,8 +409,7 @@ public class CMMStudyMapper {
                 defaultLangIsoCode,
                 document,
                 universeXPath.orElseThrow(),
-                xPaths.getNamespace(),
-                ParsingStrategies::universeStrategy
+                ParsingStrategies::universeStrategy, xPaths.getNamespace()
             );
 
             var universes = new HashMap<String, Universe>();
@@ -450,8 +444,7 @@ public class CMMStudyMapper {
 
     Map<String, List<RelatedPublication>> parseRelatedPublications(Document document, XPaths xPaths, String defaultLangIsoCode) {
         return docElementParser.extractMetadataObjectListForEachLang(
-            defaultLangIsoCode, document, xPaths.getRelatedPublicationsXPath(), xPaths.getNamespace(),
-            element -> relatedPublicationsStrategy(element, xPaths.getNamespace())
+            defaultLangIsoCode, document, xPaths.getRelatedPublicationsXPath(), ParsingStrategies::relatedPublicationsStrategy, xPaths.getNamespace()
         );
     }
 

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -119,7 +119,7 @@ class ParsingStrategies {
         );
     }
 
-    static Optional<TermVocabAttributes> termVocabAttributeStrategy(Element element, Namespace namespace, boolean hasControlledValue) {
+    static Optional<TermVocabAttributes> termVocabAttributeStrategy(Element element, boolean hasControlledValue) {
         // The term always comes from the original element
         var term = cleanCharacterReturns(element.getText());
 
@@ -129,7 +129,7 @@ class ParsingStrategies {
         String id;
         if (hasControlledValue) {
             // Try to find a concept element
-            vocabElement = ofNullable(element.getChild(CONCEPT_EL, namespace)).orElse(new Element(EMPTY_EL));
+            vocabElement = ofNullable(element.getChild(CONCEPT_EL, element.getNamespace())).orElse(new Element(EMPTY_EL));
             id = vocabElement.getText();
         } else {
             // Use the original element as the source of the vocabulary
@@ -163,9 +163,9 @@ class ParsingStrategies {
         }
     }
 
-    static Optional<VocabAttributes> samplingTermVocabAttributeStrategy(Element element, Namespace namespace) {
+    static Optional<VocabAttributes> samplingTermVocabAttributeStrategy(Element element) {
         //PUG req. only process if element has a <concept>
-        var conceptVal = element.getChild(CONCEPT_EL, namespace);
+        var conceptVal = element.getChild(CONCEPT_EL, element.getNamespace());
         if (conceptVal != null) {
             var vocabAttributes = new VocabAttributes(
                 getAttributeValue(conceptVal, VOCAB_ATTR).orElse(""),
@@ -208,10 +208,10 @@ class ParsingStrategies {
      * {@code titl} element is blank then the method attempts to extract directly from the element.
      * If a title cannot be extracted, an empty {@link Optional} is returned.
      * @param element the {@link Element} to parse.
-     * @param namespace the DDI {@link Namespace}.
      * @return a {@link RelatedPublication}, or an empty {@link Optional} if a title cannot be extracted.
      */
-    static Optional<RelatedPublication> relatedPublicationsStrategy(Element element, Namespace namespace) {
+    static Optional<RelatedPublication> relatedPublicationsStrategy(Element element) {
+        var namespace = element.getNamespace();
 
         // Result variables
         String title = null;

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -65,7 +65,7 @@ public class RecordXMLParser {
     /**
      * Load an XML document from the given path.
      * @param path the path to the XML document.
-     * @throws XMLParseException if the document could not be parsed, or an IO error occured.
+     * @throws XMLParseException if the document could not be parsed, or an IO error occurred.
      */
     private Document getDocument(Path path) throws XMLParseException {
         try (var inputStream = Files.newInputStream(path)) {

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -25,6 +25,8 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Map.entry;
+
 /**
  * XPath constants used to extract metadata from DDI XML documents.
  */
@@ -32,12 +34,13 @@ import java.util.Optional;
 @EqualsAndHashCode
 @Getter
 @ToString
+@With
 public final class XPaths implements Serializable {
     @Serial
     private static final long serialVersionUID = -6226660931460780008L;
 
     @NonNull
-    private final Namespace namespace;
+    private final Namespace[] namespace;
     // Codebook Paths
     private final String recordDefaultLanguage;
     private final String yearOfPubXPath;
@@ -91,69 +94,20 @@ public final class XPaths implements Serializable {
     }
 
     /**
-     * XPaths needed to extract metadata from DDI 3.3 documents.
-     */
-    public static final XPaths DDI_3_3_XPATHS = XPaths.builder()
-        .namespace(Namespace.getNamespace("ddi", "ddi:instance:3_3"))
-        // Abstract
-        .abstractXPath("//ddi:DDIInstance/s:StudyUnit/r:Abstract/r:Content")
-        // Study title
-        .titleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
-        // Study title (in additional languages)
-        .parTitleXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Title/r:String")
-        // 'Access study' link (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLDocDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
-        // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLStudyDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
-        // Study number/PID (when @typeOfUserID attribute is "StudyNumber")
-        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
-        // Study number/PID 
-        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
-        // Creator/PI
-        .creatorsXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Creator/r:CreatorReference")
-        // Terms of data access
-        .dataAccessUrlXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
-        // Terms of data access
-        .dataRestrctnXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
-        // Data collection period
-        .dataCollectionPeriodsXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:CollectionSituation/r:Description/r:Content")
-        // Publication year
-        .yearOfPubXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:PublicationDate/r:SimpleDate")
-        // Topics
-        .classificationsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Subject")
-        // Keywords
-        .keywordsXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:TopicalCoverage/r:Keyword")
-        // Time dimension
-        .typeOfTimeMethodXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:TimeMethod/r:Description/r:Content")
-        // Country
-        .studyAreaCountriesXPath("//ddi:DDIInstance/s:StudyUnit/r:Coverage/r:SpatialCoverage/r:Description/r:Content")
-        // Analysis unit (descriptive)
-        .unitTypeXPath("//ddi:DDIInstance/s:StudyUnit/r:AnalysisUnitsCovered")
-        // Publisher
-        .publisherXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference")
-        // Publisher Reference (Institution)
-        .distributorXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Publisher/r:PublisherReference/r:URN")
-        // Language of data file(s)
-        .fileTxtLanguagesXPath("//ddi:DDIInstance/r:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Language")
-        // Language-specific name of file
-        .filenameLanguagesXPath("//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Title/r:String")
-        // Sampling procedure (descriptive)
-        .samplingXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:Methodology/d:SamplingProcedure/r:Description/r:Content")
-        // Data collection mode (descriptive)
-        .typeOfModeOfCollectionXPath("//ddi:DDIInstance/s:StudyUnit/d:DataCollection/d:CollectionEvent/d:ModeOfCollection/r:Description/r:Content")
-        // Related publication (PID)
-        .relatedPublicationsXPath("//ddi:DDIInstance/s:StudyUnit/r:OtherMaterial/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
-        // Study description language
-        .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
-        // Description of population
-        .universeXPath("//ddi:DDIInstance/s:StudyUnit/c:ConceptualComponent/c:UniverseScheme/")
-        .build();
-
-    /**
      * XPaths needed to extract metadata from DDI 3.2 documents.
      */
+    // TODO: Add parsing implementation to this file
     public static final XPaths DDI_3_2_XPATHS = XPaths.builder()
-        .namespace(Namespace.getNamespace("ddi", "ddi:instance:3_2"))
+        .namespace(new Namespace[]{
+            Namespace.getNamespace("ddi", "ddi:instance:3_2"),
+            Namespace.getNamespace("a", "ddi:archive:3_2"),
+            Namespace.getNamespace("c", "ddi:conceptualcomponent:3_2"),
+            Namespace.getNamespace("d","ddi:datacollection:3_2"),
+            Namespace.getNamespace("g", "ddi:group:3_2"),
+            Namespace.getNamespace("pi", "ddi:physicalinstance:3_2"),
+            Namespace.getNamespace("r", "ddi:reusable:3_2"),
+            Namespace.getNamespace("s", "ddi:studyunit:3_2")
+        })
         // Abstract
         .abstractXPath("//ddi:DDIInstance/s:StudyUnit/r:Abstract/r:Content")
         // Study title
@@ -164,12 +118,12 @@ public final class XPaths implements Serializable {
         .studyURLDocDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
         // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
         .studyURLStudyDscrXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
-        // Study number/PID (when @typeOfUserID attribute is "StudyNumber")
-        .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
+        // Study number/PID (when @typeOfUserID attribute is "StudyNumber") - TODO: Implement parsing for this
+        //.pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:UserID")
         // Study number/PID 
         .pidStudyXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
         // Creator/PI
-        .creatorsXPath("//ddi:DDIInstance/s:StudyUnit/r:Citation/r:Creator/r:CreatorReference")
+        .creatorsXPath("//ddi:DDIInstance/r:Citation/r:Creator/r:CreatorName/r:String")
         // Terms of data access
         .dataAccessUrlXPath("//ddi:DDIInstance/s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content")
         // Terms of data access
@@ -204,15 +158,31 @@ public final class XPaths implements Serializable {
         .relatedPublicationsXPath("//ddi:DDIInstance/s:StudyUnit/r:OtherMaterial/r:Citation/r:InternationalIdentifier/r:IdentifierContent")
         // Study description language
         .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
-        // Description of population
-        .universeXPath("//ddi:DDIInstance/s:StudyUnit/c:ConceptualComponent/c:UniverseScheme/")
+        // Description of population - TODO: Implement inclusion/exclusion
+        .universeXPath("//ddi:DDIInstance/s:StudyUnit/c:ConceptualComponent/c:UniverseScheme")
         .build();
+
+    /**
+     * XPaths needed to extract metadata from DDI 3.3 documents.
+     */
+    public static final XPaths DDI_3_3_XPATHS = DDI_3_2_XPATHS
+        .withNamespace(new Namespace[]{
+            Namespace.getNamespace("ddi", "ddi:instance:3_3"),
+            Namespace.getNamespace("a", "ddi:archive:3_3"),
+            Namespace.getNamespace("c", "ddi:conceptualcomponent:3_3"),
+            Namespace.getNamespace("d","ddi:datacollection:3_3"),
+            Namespace.getNamespace("g", "ddi:group:3_3"),
+            Namespace.getNamespace("pi", "ddi:physicalinstance:3_3"),
+            Namespace.getNamespace("r", "ddi:reusable:3_3"),
+            Namespace.getNamespace("s", "ddi:studyunit:3_3")
+        });
+
 
     /**
      * XPaths needed to extract metadata from DDI 2.5 documents.
      */
     public static final XPaths DDI_2_5_XPATHS = XPaths.builder()
-        .namespace(Namespace.getNamespace("ddi", "ddi:codebook:2_5"))
+        .namespace(new Namespace[]{ Namespace.getNamespace("ddi", "ddi:codebook:2_5") })
         // Abstract
         .abstractXPath("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract")
         // Study title
@@ -269,7 +239,7 @@ public final class XPaths implements Serializable {
      * XPaths needed to extract metadata from NESSTAR flavoured DDI 1.2.2 documents.
      */
     public static final XPaths NESSTAR_XPATHS = XPaths.builder()
-        .namespace(Namespace.getNamespace("ddi", "http://www.icpsr.umich.edu/DDI"))
+        .namespace(new Namespace[]{ Namespace.getNamespace("ddi", "http://www.icpsr.umich.edu/DDI") })
         .recordDefaultLanguage("//ddi:codeBook/@xml-lang") // Nesstar with "-"
         // Closest for Nesstar based on CMM mapping doc but the above existing one for ddi2.5 seems to be present in Nesstar
         .yearOfPubXPath("//ddi:codeBook/stdyDscr/citation/distStmt/distDate[1]/@date")
@@ -301,10 +271,10 @@ public final class XPaths implements Serializable {
      * Mapping of XML namespaces to XPaths
      */
     private static final Map<Namespace, XPaths> XPATH_MAP = Map.ofEntries(
-        Map.entry(DDI_3_3_XPATHS.getNamespace(), DDI_3_3_XPATHS),
-        Map.entry(DDI_3_2_XPATHS.getNamespace(), DDI_3_2_XPATHS),
-        Map.entry(DDI_2_5_XPATHS.getNamespace(), DDI_2_5_XPATHS),
-        Map.entry(NESSTAR_XPATHS.getNamespace(), NESSTAR_XPATHS)
+        entry(DDI_3_3_XPATHS.getNamespace()[0], DDI_3_3_XPATHS),
+        entry(DDI_3_2_XPATHS.getNamespace()[0], DDI_3_2_XPATHS),
+        entry(DDI_2_5_XPATHS.getNamespace()[0], DDI_2_5_XPATHS),
+        entry(NESSTAR_XPATHS.getNamespace()[0], NESSTAR_XPATHS)
     );
 
     /**

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017-2023 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.pasc.oci.parser;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jackson.JsonLoader;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import eu.cessda.pasc.oci.ResourceHandler;
+import eu.cessda.pasc.oci.configurations.Repo;
+import eu.cessda.pasc.oci.exception.IndexerException;
+import eu.cessda.pasc.oci.mock.data.ReposTestData;
+import eu.cessda.pasc.oci.models.cmmstudy.CMMStudy;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.TimeZone;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+
+/**
+ * Tests related to {@link RecordXMLParser}
+ *
+ * @author moses AT doraventures DOT com
+ */
+@Slf4j
+public class RecordXMLParserDDI3Test {
+
+    private final Repo repo = ReposTestData.getUKDSRepo();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // Class under test
+    private final CMMStudyMapper cmmStudyMapper = new CMMStudyMapper();
+
+    public RecordXMLParserDDI3Test() {
+        // Needed because TimeUtility only works properly in UTC timezones
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Test
+    public void shouldReturnValidCMMStudyRecordFromAFullyComplaintCmmDdiRecord() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+        // Given
+        var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_ddi_3.json");
+        var recordXML = ResourceHandler.getResource("xml/ddi_3_2/synthetic_compliant_cmm_ddi3.xml");
+
+        // When
+        var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
+
+        then(result).hasSize(1);
+        validateCMMStudyResultAgainstSchema(result.get(0));
+
+        String actualJson = objectMapper.writeValueAsString(result.get(0));
+
+        // Check if the JSON generated differs from the expected source
+        assertEquals(expectedJson, actualJson, true);
+    }
+
+    private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException, JSONException {
+        String jsonString = objectMapper.writeValueAsString(record);
+        JSONObject json = new JSONObject(jsonString);
+        log.debug("RETRIEVED STUDY JSON: \n" + json.toString(4));
+
+        JsonNode jsonNodeRecord = JsonLoader.fromString(jsonString);
+        final JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:/json/schema/CMMStudy.schema.json");
+
+        ProcessingReport validate = schema.validate(jsonNodeRecord);
+        if (!validate.isSuccess()) {
+            fail("Validation not successful : " + validate);
+        }
+    }
+}

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -1,0 +1,134 @@
+{
+  "abstract": {
+    "en": "Attitude of the political leadership (members of parliament) in the USA to other nations and problems in world politics.",
+    "de": "Einstellung der politischen Führungsschicht (Parlamentsmitglieder) in den USA zu anderen Nationen und weltpolitischen Problemen."
+  },
+  "classifications": {
+    "de": [
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Politische Fragen (Issues)",
+        "id": ""
+      },
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Internationale Politik und Internationale Organisationen",
+        "id": ""
+      },
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Konflikte, Sicherheit und Frieden",
+        "id": ""
+      }
+    ],
+    "en": [
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Political Issues",
+        "id": ""
+      },
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "International politics and organisations",
+        "id": ""
+      },
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Conflict, security and peace",
+        "id": ""
+      }
+    ]
+  },
+  "creators": {
+    "en": [
+      "GESIS - Leibniz Institute for the Social Sciences"
+    ],
+    "de": [
+      "GESIS - Leibniz Institut für Sozialwissenschaften"
+    ]
+  },
+  "dataAccessFreeTexts": {
+    "en": [
+      "Data and documents are only released for academic research and teaching after the data depositor's written authorization."
+    ],
+    "de": [
+      "Daten und Dokumente sind für die akademische Forschung und Lehre nur nach schriftlicher Genehmigung des Datengebers zugänglich."
+    ]
+  },
+  "dataAccessUrl": {
+  },
+  "dataCollectionFreeTexts": {
+  },
+  "dataCollectionYear": 0,
+  "fileLanguages": [
+  ],
+  "keywords": {
+  },
+  "lastModified": "2023-12-06T13:30:08.8725293Z",
+  "pidStudies": {
+    "en": [
+      {
+        "pid": "doi:10.4232/1.0004"
+      }
+    ]
+  },
+  "publisher": {
+    "en": {
+      "abbr": "Publisher not specified",
+      "publisher": ""
+    }
+  },
+  "relatedPublications": {
+  },
+  "repositoryUrl": "http://dbkapps.gesis.org/dbkoai/oai.asp",
+  "samplingProcedureFreeTexts": {
+    "en": [
+      "Quota sample"
+    ],
+    "de": [
+      "Quotenauswahl"
+    ]
+  },
+  "studyAreaCountries": {
+  },
+  "studyNumber": "oai:dbk.gesis.org:DBK/ZA0004",
+  "studyUrl": {
+  },
+  "studyXmlSourceUrl": "https://oai.ukdataservice.ac.uk:8443/oai/provider?verb=GetRecord&identifier=oai%3Adbk.gesis.org%3ADBK%2FZA0004&metadataPrefix=ddi",
+  "titleStudy": {
+    "en": "International Outlooks of Political Leaders (USA)",
+    "de": "International Outlooks of Political Leaders (USA)"
+  },
+  "typeOfModeOfCollections": {
+    "en": [
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Oral survey with standardized questionnaire",
+        "id": ""
+      }
+    ],
+    "de": [
+      {
+        "vocabUri": "",
+        "vocab": "",
+        "term": "Mündliche Befragung mit standardisiertem Fragebogen",
+        "id": ""
+      }
+    ]
+  },
+  "typeOfSamplingProcedures": {
+  },
+  "typeOfTimeMethods": {
+  },
+  "unitTypes": {
+  },
+  "universe": {
+  }
+}

--- a/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3.xml
+++ b/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3.xml
@@ -1,0 +1,475 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- $Workfile: oai.asp $ $Revision: 15 $ $Date: 2/23/04 5:30p $ -->
+<!-- $Workfile: functions.inc $ $Revision: 14 $ $Date: 2/17/16 5:30p $ -->
+<?xml-stylesheet type='text/xsl' href='./oai2html.xsl' ?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:ddi="ddi:instance:3_2" xmlns:s="ddi:studyunit:3_2"
+         xmlns:pi="ddi:physicalinstance:3_2" xmlns:c="ddi:conceptualcomponent:3_2"
+         xmlns:l="ddi:logicalproduct:3_2" xmlns:r="ddi:reusable:3_2" xmlns:d="ddi:datacollection:3_2"
+         xmlns:a="ddi:archive:3_2" xmlns:dc="http://purl.org/dc/terms/"
+         xmlns:g="ddi:group:3_2"
+         xsi:schemaLocation="ddi:instance:3_2 http://www.ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/instance.xsd
+         http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+<responseDate>2023-12-05T10:54:28Z</responseDate>
+<!-- $Workfile: GetRecord.asp $ $Revision: 13 $ $Date: 2/17/16 5:30p $ -->
+<request verb="GetRecord" identifier="oai:dbk.gesis.org:DBK/ZA0004" metadataPrefix="oai_ddi32">http://dbkapps.gesis.org/dbkoai/oai.asp</request>
+<GetRecord>
+<record>
+<header>
+    <identifier>oai:dbk.gesis.org:DBK/ZA0004</identifier>
+    <datestamp>2023-12-06T13:30:08.8725293Z</datestamp>
+    <setSpec>DBK</setSpec>
+</header>
+<metadata>
+<!-- $Workfile: metadata-ddi32.asp $ $Revision: 10 $ $Date: 2/17/16 5:30p $ -->
+<ddi:DDIInstance>
+    <r:Agency>de.gesis</r:Agency>
+    <r:ID>gesis_ZA0004</r:ID>
+    <r:Version>1.0.0</r:Version>
+    <r:Citation>
+        <r:Title>
+            <r:String xml:lang="en">DDI3.2 study level documentation for study ZA0004 International Outlooks of
+                Political Leaders (USA)
+            </r:String>
+            <r:String xml:lang="de">DDI3.2 Dokumentation auf Studienebene für Studie ZA0004 International Outlooks of
+                Political Leaders (USA)
+            </r:String>
+        </r:Title>
+        <r:Creator>
+            <r:CreatorName>
+                <r:String xml:lang="en">GESIS - Leibniz Institute for the Social Sciences</r:String>
+                <r:String xml:lang="de">GESIS - Leibniz Institut für Sozialwissenschaften</r:String>
+            </r:CreatorName>
+        </r:Creator>
+        <r:Publisher>
+            <r:PublisherName>
+                <r:String xml:lang="en">GESIS - Leibniz Institute for the Social Sciences</r:String>
+                <r:String xml:lang="de">GESIS - Leibniz Institut für Sozialwissenschaften</r:String>
+            </r:PublisherName>
+        </r:Publisher>
+        <r:Language>de</r:Language>
+        <r:Copyright>
+            <r:String xml:lang="en">All metadata from GESIS DBK are available free of restriction under the Creative
+                Commons CC0 1.0 Universal Public Domain Dedication. However, GESIS requests that you actively
+                acknowledge and give attribution to all metadata sources, such as the data providers and any data
+                aggregators, including GESIS. For further information see https://dbk.gesis.org/dbksearch/guidelines.asp
+            </r:String>
+            <r:String xml:lang="de">Alle im GESIS DBK veröffentlichten Metadaten sind frei verfügbar unter den Creative
+                Commons CC0 1.0 Universal Public Domain Dedication. GESIS bittet jedoch darum, dass Sie alle
+                Metadatenquellen anerkennen und sie nennen, etwa die Datengeber oder jeglichen Aggregator, inklusive
+                GESIS selbst. Für weitere Informationen siehe https://dbk.gesis.org/dbksearch/guidelines.asp?db=d
+            </r:String>
+        </r:Copyright>
+        <dc:hasVersion>1.0.0</dc:hasVersion>
+    </r:Citation>
+    <g:ResourcePackage>
+        <r:Agency>de.gesis</r:Agency>
+        <r:ID>ZA0004_ResPac</r:ID>
+        <r:Version>1.0.0</r:Version>
+        <a:OrganizationScheme>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_OrgSch</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <a:Organization>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_Cre1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <a:OrganizationIdentification>
+                    <a:OrganizationName>
+                        <r:String>Institute for International Social Research, Princeton, N.J.</r:String>
+                    </a:OrganizationName>
+                </a:OrganizationIdentification>
+            </a:Organization>
+            <a:Organization>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_Pub1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <a:OrganizationIdentification>
+                    <a:OrganizationName>
+                        <r:String xml:lang="en">GESIS - Leibniz Institute for the Social Sciences</r:String>
+                        <r:String xml:lang="de">GESIS - Leibniz Institut für Sozialwissenschaften</r:String>
+                    </a:OrganizationName>
+                </a:OrganizationIdentification>
+            </a:Organization>
+            <a:Organization>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_AR</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <a:OrganizationIdentification>
+                    <a:OrganizationName>
+                        <r:String xml:lang="en">GESIS - Leibniz Institute for the Social Sciences</r:String>
+                        <r:String xml:lang="de">GESIS - Leibniz Institut für Sozialwissenschaften</r:String>
+                    </a:OrganizationName>
+                </a:OrganizationIdentification>
+                <r:Description>
+                    <r:Content xml:lang="en">GESIS Data service</r:Content>
+                    <r:Content xml:lang="de">GESIS Datenservice</r:Content>
+                </r:Description>
+                <a:ContactInformation>
+                    <a:Telephone>
+                        <a:TelephoneNumber>+49 (0)221-476 94-420</a:TelephoneNumber>
+                    </a:Telephone>
+                    <a:URL>http://www.gesis.org/</a:URL>
+                    <a:Email>
+                        <r:InternetEmail>datenservice.das@gesis.org</r:InternetEmail>
+                    </a:Email>
+                </a:ContactInformation>
+            </a:Organization>
+            <a:Organization>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_DC</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <a:OrganizationIdentification>
+                    <a:OrganizationName>
+                        <r:String>Institute for International Social Research, Princeton, N.J.
+                        </r:String>
+                    </a:OrganizationName>
+                </a:OrganizationIdentification>
+            </a:Organization>
+        </a:OrganizationScheme>
+        <c:UniverseScheme>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_UniSch</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <c:Universe>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Uni1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:Description>
+                    <r:Content xml:lang="en">Members of congress (Senate and House of Representatives).
+                    </r:Content>
+                    <r:Content xml:lang="de">Kongressmitglieder (Senat und Repräsentantenhaus)</r:Content>
+                </r:Description>
+            </c:Universe>
+        </c:UniverseScheme>
+        <c:GeographicLocationScheme>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_GeoLocSch</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:GeographicLocation>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_GeoLocUS</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:Description>
+                    <r:Content xml:lang="en"/>
+                    <r:Content xml:lang="de"/>
+                </r:Description>
+                <r:GeographicLevelDescription>
+                    <r:Content>Countries and Regions (ISO3166-1/2)</r:Content>
+                </r:GeographicLevelDescription>
+                <r:LocationValue>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_LocValUS</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:LocationValueName>
+                        <r:String xml:lang="en">United States of America</r:String>
+                        <r:String xml:lang="de">Vereinigte Staaten von Amerika</r:String>
+                    </r:LocationValueName>
+                    <r:GeographicLocationIdentifier>
+                        <r:GeographicCode>US</r:GeographicCode>
+                    </r:GeographicLocationIdentifier>
+                </r:LocationValue>
+            </r:GeographicLocation>
+        </c:GeographicLocationScheme>
+    </g:ResourcePackage>
+    <s:StudyUnit versionDate="2010-04-13">
+        <r:Agency>de.gesis</r:Agency>
+        <r:ID>ZA0004_SU</r:ID>
+        <r:Version>1.0.0</r:Version>
+        <r:UserID typeOfUserID="StudyNumber">ZA0004</r:UserID>
+        <r:UserID typeOfUserID="VersionNumber">1.0.0</r:UserID>
+        <r:Note>
+            <r:TypeOfNote codeListName="GesisTypeOfNote" codeListAgencyName="Gesis" codeListURN="">FurtherRemarks</r:TypeOfNote>
+            <r:Relationship>
+                <r:RelatedToReference>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_SU</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:TypeOfObject>StudyUnit</r:TypeOfObject>
+                </r:RelatedToReference>
+            </r:Relationship>
+            <r:Header>
+                <r:String xml:lang="en">Further Remarks</r:String>
+                <r:String xml:lang="de">Weitere Hinweise</r:String>
+            </r:Header>
+            <r:NoteContent>
+                <r:Content xml:lang="en">The study is part of an international comparative investigation (see
+                    ZA Study Nos. 0005 to 0010).
+                </r:Content>
+                <r:Content xml:lang="de">Die Studie ist Teil einer international vergleichenden Untersuchung
+                    (vgl. ZA-Studien-Nrn. 0005 bis 0010).
+                </r:Content>
+            </r:NoteContent>
+        </r:Note>
+        <r:Citation>
+            <r:Title>
+                <r:String xml:lang="en">International Outlooks of Political Leaders (USA)</r:String>
+                <r:String xml:lang="de">International Outlooks of Political Leaders (USA)</r:String>
+            </r:Title>
+            <r:Creator>
+                <r:CreatorReference>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_Org_Cre1</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:TypeOfObject>Organization</r:TypeOfObject>
+                </r:CreatorReference>
+            </r:Creator>
+            <r:Publisher>
+                <r:PublisherReference>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_Org_Pub1</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:TypeOfObject>Organization</r:TypeOfObject>
+                </r:PublisherReference>
+            </r:Publisher>
+            <r:PublicationDate>
+                <r:SimpleDate>1964</r:SimpleDate>
+            </r:PublicationDate>
+            <r:InternationalIdentifier>
+                <r:IdentifierContent>doi:10.4232/1.0004</r:IdentifierContent>
+                <r:ManagingAgency>DOI</r:ManagingAgency>
+            </r:InternationalIdentifier>
+        </r:Citation>
+        <r:Abstract>
+            <r:Content xml:lang="en">Attitude of the political leadership (members of parliament) in the USA to other nations and problems in world politics.</r:Content>
+            <r:Content xml:lang="de">Einstellung der politischen Führungsschicht (Parlamentsmitglieder) in den USA zu anderen Nationen und weltpolitischen Problemen.</r:Content>
+        </r:Abstract>
+        <r:UniverseReference>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_Uni1</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:TypeOfObject>Universe</r:TypeOfObject>
+        </r:UniverseReference>
+        <r:Coverage>
+            <r:TopicalCoverage>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Top</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:Subject xml:lang="en" codeListAgencyName="de.gesis" codeListName="ZA-Categories">Political Issues</r:Subject>
+                <r:Subject xml:lang="de" codeListAgencyName="de.gesis" codeListName="ZA-Kategorien">Politische Fragen (Issues)</r:Subject>
+                <r:Subject xml:lang="en" codeListAgencyName="cessda" codeListName="CESSDA Topic Classification">International politics and organisations</r:Subject>
+                <r:Subject xml:lang="de" codeListAgencyName="cessda" codeListName="CESSDA Topic Classification">Internationale Politik und Internationale Organisationen</r:Subject>
+                <r:Subject xml:lang="en" codeListAgencyName="cessda" codeListName="CESSDA Topic Classification">Conflict, security and peace</r:Subject>
+                <r:Subject xml:lang="de" codeListAgencyName="cessda" codeListName="CESSDA Topic Classification">Konflikte, Sicherheit und Frieden</r:Subject>
+            </r:TopicalCoverage>
+            <r:SpatialCoverage>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Spa</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:GeographicLocationReference>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_GeoLocUS</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:TypeOfObject>GeographicLocation</r:TypeOfObject>
+                </r:GeographicLocationReference>
+            </r:SpatialCoverage>
+            <r:TemporalCoverage>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Tem</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:ReferenceDate>
+                    <r:StartDate>1958-02</r:StartDate>
+                    <r:EndDate>1958-04</r:EndDate>
+                    <r:Subject xml:lang="de"/>
+                </r:ReferenceDate>
+            </r:TemporalCoverage>
+        </r:Coverage>
+        <r:OtherMaterial>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_Mat4</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:TypeOfMaterial codeListAgencyName="gesis" codeListName="GesisTypeOfMaterial">OriginalLiterature
+            </r:TypeOfMaterial>
+            <r:Description>
+                <r:Content>Free, Lloyd A.:
+                    Six Allies And A Neutral.
+                    Glencoe, Ill.: Free Press 1959
+                </r:Content>
+            </r:Description>
+        </r:OtherMaterial>
+        <r:OtherMaterial xml:lang="de">
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_OthMat54968</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:UserID typeOfUserID="Dokument-ID">54968</r:UserID>
+            <r:TypeOfMaterial codeListName="GesisDBKTypeOfMaterial">Questionnaire</r:TypeOfMaterial>
+            <r:Description>
+                <r:Content xml:lang="en"/>
+                <r:Content xml:lang="de"/>
+            </r:Description>
+            <r:Citation>
+                <r:Title>
+                    <r:String xml:lang="en">ZA0004-10_q.pdf (Questionnaire)</r:String>
+                    <r:String xml:lang="de">ZA0004-10_q.pdf (Fragebogen)</r:String>
+                </r:Title>
+            </r:Citation>
+            <r:ExternalURLReference>https://dbk.gesis.org/dbksearch/download.asp?id=54968</r:ExternalURLReference>
+        </r:OtherMaterial>
+        <d:DataCollection>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_DatCol</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <d:Methodology>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Met</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <d:SamplingProcedure>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_SamPro</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:Description>
+                        <r:Content xml:lang="en">Quota sample</r:Content>
+                        <r:Content xml:lang="de">Quotenauswahl</r:Content>
+                    </r:Description>
+                </d:SamplingProcedure>
+            </d:Methodology>
+            <d:CollectionEvent>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_ColEve</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <d:DataCollectorOrganizationReference>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_Org_DC</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:TypeOfObject>Organization</r:TypeOfObject>
+                </d:DataCollectorOrganizationReference>
+                <d:DataCollectionDate>
+                    <r:StartDate>1958-02</r:StartDate>
+                    <r:EndDate>1958-04</r:EndDate>
+                </d:DataCollectionDate>
+                <d:ModeOfCollection>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_ModOfC</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:Description>
+                        <r:Content xml:lang="en">Oral survey with standardized questionnaire</r:Content>
+                        <r:Content xml:lang="de">Mündliche Befragung mit standardisiertem Fragebogen</r:Content>
+                    </r:Description>
+                </d:ModeOfCollection>
+            </d:CollectionEvent>
+            <d:InstrumentScheme>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_InstrumentSch</r:ID>
+                <r:Version>1.0.0</r:Version>
+            </d:InstrumentScheme>
+        </d:DataCollection>
+        <l:LogicalProduct>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_LogPro</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:Note>
+                <r:TypeOfNote codeListName="GesisTypeOfNote" codeListAgencyName="Gesis" codeListURN="">Software
+                </r:TypeOfNote>
+                <r:Relationship>
+                    <r:RelatedToReference>
+                        <r:Agency>de.gesis</r:Agency>
+                        <r:ID>ZA0004_LogPro</r:ID>
+                        <r:Version>1.0.0</r:Version>
+                        <r:TypeOfObject>LogicalProduct</r:TypeOfObject>
+                    </r:RelatedToReference>
+                </r:Relationship>
+                <r:NoteContent>
+                    <r:Content xml:lang="en">-</r:Content>
+                    <r:Content xml:lang="de">-</r:Content>
+                </r:NoteContent>
+            </r:Note>
+            <r:Note>
+                <r:TypeOfNote codeListName="GesisTypeOfNote" codeListAgencyName="Gesis" codeListURN="">
+                    VariableQuantity
+                </r:TypeOfNote>
+                <r:Relationship>
+                    <r:RelatedToReference>
+                        <r:Agency>de.gesis</r:Agency>
+                        <r:ID>ZA0004_LogPro</r:ID>
+                        <r:Version>1.0.0</r:Version>
+                        <r:TypeOfObject>LogicalProduct</r:TypeOfObject>
+                    </r:RelatedToReference>
+                </r:Relationship>
+                <r:NoteContent>
+                    <r:Content xml:lang="en">0</r:Content>
+                    <r:Content xml:lang="de">0</r:Content>
+                </r:NoteContent>
+            </r:Note>
+        </l:LogicalProduct>
+        <pi:PhysicalInstance>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_PhyIns</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <pi:GrossFileStructure>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_GroFilStr</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <pi:CaseQuantity>98</pi:CaseQuantity>
+            </pi:GrossFileStructure>
+        </pi:PhysicalInstance>
+        <a:Archive>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_Arc</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <a:ArchiveSpecific>
+                <a:Item>
+                    <a:Access>
+                        <r:Agency>de.gesis</r:Agency>
+                        <r:ID>ZA0004_Acc</r:ID>
+                        <r:Version>1.0.0</r:Version>
+                        <a:AccessTypeName context="info:eu-repo-Access-Terms vocabulary">
+                            <r:String>C</r:String>
+                        </a:AccessTypeName>
+                        <r:Description>
+                            <r:Content xml:lang="en">Data and documents are only released for academic research and teaching after the data depositor's written authorization.</r:Content>
+                            <r:Content xml:lang="de">Daten und Dokumente sind für die akademische Forschung und Lehre nur nach schriftlicher Genehmigung des Datengebers zugänglich.</r:Content>
+                        </r:Description>
+                        <a:ContactOrganizationReference>
+                            <r:Agency>de.gesis</r:Agency>
+                            <r:ID>ZA0004_Org_AR</r:ID>
+                            <r:Version>1.0.0</r:Version>
+                            <r:TypeOfObject>Organization</r:TypeOfObject>
+                        </a:ContactOrganizationReference>
+                    </a:Access>
+                </a:Item>
+            </a:ArchiveSpecific>
+            <r:LifecycleInformation>
+                <r:LifecycleEvent>
+                    <r:Agency>de.gesis</r:Agency>
+                    <r:ID>ZA0004_LifEve</r:ID>
+                    <r:Version>1.0.0</r:Version>
+                    <r:AgencyOrganizationReference>
+                        <r:Agency>de.gesis</r:Agency>
+                        <r:ID>ZA0004_Org_AR</r:ID>
+                        <r:Version>1.0.0</r:Version>
+                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                    </r:AgencyOrganizationReference>
+                    <r:Description>
+                        <r:Content><![CDATA[
+ Selection of DDI 3.2 Elements and Attributes used by DBK for DDI3.2 Export 
+ The original DDI 3.2 Schema can be found at http://www.ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ 
+ A copy of the DDI 3.2 Schema can be found at http://dbkapps.gesis.org/DDI/3_2 
+                                         
+ Documentation of the metadata schema:                 
+ Akdeniz, Esra, And Wolfgang Zenk-Möltgen. 2017:       
+ DDI-Lifecycle im Datenarchiv. Das Metadatenschema     
+ für die Dokumentation in verschiedenen                
+ Softwaresystemen.GESIS Papers 2017/02.                
+ http://nbn-resolving.de/urn:nbn:de:0168-ssoar-50354-9 
+ https://dbk.gesis.org/ddi/DDI-LimDAS/                 
+                                                       
+                                         
+ created by W. Zenk-Möltgen, 2019-07-25  
+ from DBK                   
+ DDI3.2 export format                    
+                                         
+ DBK 2.2 to DDI 3.2 Export - 2.8.5       
+                                         
+]]>
+                        </r:Content>
+                    </r:Description>
+                </r:LifecycleEvent>
+            </r:LifecycleInformation>
+        </a:Archive>
+    </s:StudyUnit>
+
+</ddi:DDIInstance>
+</metadata>
+</record>
+</GetRecord>
+</OAI-PMH>


### PR DESCRIPTION
This adds the ability for multiple namespaces to be part of XPaths searching for target elements, which is required for DDI 3.x documents. This also adds an exemplar DDI 3.2 document for testing parser features.

 Closes cessda/cessda.cdc.versions#624, closes cessda/cessda.cdc.versions#625.