### PR TITLE
Fix instances where structured logging fields wouldn't be set as expected

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -31,6 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static net.logstash.logback.argument.StructuredArguments.value;
+
 /**
  * Component responsible for extracting and mapping languages in which a given CMMStudy is available.
  * <p>
@@ -69,7 +71,7 @@ public class LanguageExtractor {
                 langCode -> getCmmStudyOfLanguage(cmmStudy, langCode, validLanguages, repository)
             ));
         } else {
-            log.debug("[{}] No valid languages for study [{}]", repository.code(), cmmStudy.studyNumber());
+            log.debug("[{}] No valid languages for study [{}]",  value(LoggingConstants.REPO_NAME, repository.code()), value(LoggingConstants.STUDY_ID,cmmStudy.studyNumber()));
             return Collections.emptyMap();
         }
     }
@@ -94,7 +96,11 @@ public class LanguageExtractor {
 
     private CMMStudyOfLanguage getCmmStudyOfLanguage(CMMStudy cmmStudy, String lang, Collection<String> availableLanguages, Repo repository) {
 
-        log.trace("[{}] Extracting CMMStudyOfLanguage for study [{}], language [{}]", repository.code(), cmmStudy.studyNumber(), lang);
+        log.trace("[{}] Extracting CMMStudyOfLanguage for study [{}], language [{}]",
+            value(LoggingConstants.REPO_NAME, repository.code()),
+            value(LoggingConstants.STUDY_ID, cmmStudy.studyNumber()),
+            value(LoggingConstants.LANG_CODE, lang)
+        );
 
         CMMStudyOfLanguage.CMMStudyOfLanguageBuilder builder = CMMStudyOfLanguage.builder();
 

--- a/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
+++ b/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
@@ -50,7 +50,7 @@ public class OCIApplication {
 
     @Component
     @Profile("!test")
-    @SuppressWarnings("java:S3985")
+    @SuppressWarnings({"java:S3985", "UnusedNestedClass"})
     private class Runner implements CommandLineRunner {
         /**
          * Run the indexer. If an exception is thrown, the exit code of the indexer is set to -1.

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -38,6 +38,7 @@ import static java.util.Map.entry;
 @Getter(value = AccessLevel.PACKAGE)
 @ToString
 @With
+@SuppressWarnings("UnnecessaryLambda")
 public final class XPaths {
 
     @NonNull

--- a/src/test/java/eu/cessda/pasc/oci/IndexerConsumerServiceTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/IndexerConsumerServiceTest.java
@@ -81,6 +81,6 @@ public class IndexerConsumerServiceTest {
 
         // When
         assertThatThrownBy(() -> indexerConsumerService.getRecords(ukdsEndpoint))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NullPointerException.class);
     }
 }

--- a/src/test/java/eu/cessda/pasc/oci/exception/IndexerExceptionTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/exception/IndexerExceptionTest.java
@@ -18,6 +18,7 @@ package eu.cessda.pasc.oci.exception;
 import org.junit.Assert;
 import org.junit.Test;
 
+@SuppressWarnings("StaticAssignmentOfThrowable")
 public class IndexerExceptionTest {
 
     private static final Exception INNER_EXCEPTION = new Exception("Inner exception");

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserNesstarTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserNesstarTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
+@SuppressWarnings("NonApiType")
 public class RecordXMLParserNesstarTest {
 
     private final Repo nesstarRepo = ReposTestData.getNSDRepo();


### PR DESCRIPTION
Whilst investigating https://github.com/cessda/cessda.cdc.versions/issues/641, it was discovered that the `repo_name` logging field wasn't being set consistently. This commit adds explicit `value()` calls when logging where these were missing.