### PR TITLE
#560: Parse funding information into the CMMStudy model

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -146,6 +146,7 @@ public class LanguageExtractor {
         Optional.ofNullable(cmmStudy.dataAccessFreeTexts()).map(map -> map.get(lang)).ifPresent(builder::dataAccessFreeTexts);
         Optional.ofNullable(cmmStudy.publisher()).map(map -> map.get(lang)).ifPresent(builder::publisher);
         Optional.ofNullable(cmmStudy.universe()).map(map -> map.get(lang)).ifPresent(builder::universe);
+        Optional.ofNullable(cmmStudy.funding()).map(map -> map.get(lang)).ifPresent(builder::funding);
 
         // #502 - Use any language to set related publications, override with language specific field if present
         Optional.ofNullable(cmmStudy.relatedPublications()).flatMap(map -> map.values().stream().filter(Objects::nonNull).findAny()).ifPresent(builder::relatedPublications);

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
@@ -47,6 +47,7 @@ public record CMMStudy(
     @JsonProperty("dataCollectionYear") int dataCollectionYear,
     @JsonProperty("dataCollectionFreeTexts") Map<String, List<DataCollectionFreeText>> dataCollectionFreeTexts,
     @JsonProperty("fileLanguages") Set<String> fileLanguages,
+    @JsonProperty("funding") Map<String, List<Funding>> funding,
     @JsonProperty("keywords") Map<String, List<TermVocabAttributes>> keywords,
     @JsonProperty("pidStudies") Map<String, List<Pid>> pidStudies,
     @JsonProperty("publicationYear") String publicationYear,

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
@@ -49,6 +49,7 @@ public record CMMStudyOfLanguage(
     @JsonProperty("dataAccessFreeTexts") List<String> dataAccessFreeTexts,
     @JsonProperty("dataAccessUrl") URI dataAccessUrl,
     @JsonProperty("fileLanguages") Set<String> fileLanguages,
+    @JsonProperty("funding") List<Funding> funding,
     @JsonProperty("keywords") List<TermVocabAttributes> keywords,
     @JsonProperty("pidStudies") List<Pid> pidStudies,
     @JsonProperty("publicationYear") String publicationYear,

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/Funding.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/Funding.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017-2024 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.pasc.oci.models.cmmstudy;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record Funding(
+    String grantNumber,
+    String agency
+) {
+}

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -447,6 +447,11 @@ public class CMMStudyMapper {
         }
     }
 
+    Map<String, List<Funding>> parseFunding(Document document, XPaths xPaths, String defaultLangIsoCode) {
+        var unmappedXPaths = xPaths.getFundingXPath().resolve(document, xPaths.getNamespace());
+        return mapNullLanguage(unmappedXPaths, defaultLangIsoCode);
+    }
+
     @Value
     public static class HeaderElement {
         String studyNumber;

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -302,6 +302,7 @@ public class RecordXMLParser {
                 log.warn("[{}] Some universes in study {} couldn't be parsed: {}", repository.code(), studyNumber, e.toString());
             }
             builder.relatedPublications(cmmStudyMapper.parseRelatedPublications(metadata, xPaths, defaultLangIsoCode));
+            builder.funding(cmmStudyMapper.parseFunding(metadata, xPaths, defaultLangIsoCode));
         }
 
         URI repositoryUrl;

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Function;
 
-import static eu.cessda.pasc.oci.parser.ParsingStrategies.termVocabAttributeStrategy;
+import static eu.cessda.pasc.oci.parser.ParsingStrategies.*;
 import static eu.cessda.pasc.oci.parser.XMLMapper.*;
 import static java.util.Map.entry;
 
@@ -75,6 +75,7 @@ public final class XPaths {
     @Nullable
     private final XMLMapper<Map<String, List<UniverseElement>>> universeXPath;
     private final XMLMapper<Map<String, List<String>>> creatorsXPath;
+    private final XMLMapper<Map<String, List<Funding>>> fundingXPath;
 
     private static final CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateNotParsedException>> EMPTY_PARSE_RESULTS = new CMMStudyMapper.ParseResults<>(
         new CMMStudyMapper.DataCollectionPeriod(null, 0, null, Collections.emptyMap()),
@@ -122,11 +123,11 @@ public final class XPaths {
         // Keywords
         .keywordsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Keyword", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_2_STRATEGY)))
         // Time dimension
-        .typeOfTimeMethodXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> ParsingStrategies.typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .typeOfTimeMethodXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Country
         .studyAreaCountriesXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:SpatialCoverage/r:GeographicLocationReference", ParsingStrategies::geographicLocationStrategy))
         // Analysis unit
-        .unitTypeXPath(new XMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> ParsingStrategies.analysisUnitStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .unitTypeXPath(new XMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> analysisUnitStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Publisher
         .publisherXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Publisher/r:PublisherReference", ParsingStrategies::publisherReferenceStrategy))
         // Language of data file(s)
@@ -134,9 +135,9 @@ public final class XPaths {
         // Language-specific name of file
         .filenameLanguagesXPath(new XMLMapper<>("//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Title/r:String", XMLMapper::getLanguagesOfElements))
         // Sampling procedure
-        .samplingXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> ParsingStrategies.samplingProceduresLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .samplingXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> samplingProceduresLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Data collection mode
-        .typeOfModeOfCollectionXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> ParsingStrategies.typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .typeOfModeOfCollectionXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // PID of Related publication
         .relatedPublicationsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
         /// /r:Citation/r:InternationalIdentifier/r:IdentifierContent
@@ -144,6 +145,8 @@ public final class XPaths {
         .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
         // Description of population
         .universeXPath(new XMLMapper<>("//s:StudyUnit[1]/c:ConceptualComponent/c:UniverseScheme/c:Universe", ParsingStrategies::universeLifecycleStrategy))
+        // Funding information
+        .fundingXPath(new XMLMapper<>("//s:StudyUnit[1]/r:FundingInformation", ParsingStrategies::fundingLifecycleStrategy))
         .build();
 
     private static final TermVocabAttributeNames DDI_3_3_ATTR_NAMES = new TermVocabAttributeNames("controlledVocabularyName", "controlledVocabularyURN");
@@ -258,6 +261,8 @@ public final class XPaths {
         .recordDefaultLanguage("//ddi:codeBook/@xml:lang")
         // Description of population
         .universeXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
+        // Funding information
+        .fundingXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:prodStmt/ddi:grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
         .build();
 
     /**
@@ -290,6 +295,8 @@ public final class XPaths {
         .typeOfModeOfCollectionXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/collMode",  elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
         .relatedPublicationsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/othrStdyMat/relPubl", extractMetadataObjectListForEachLang(ParsingStrategies::relatedPublicationsStrategy)))
         .universeXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
+        // Funding information
+        .fundingXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/prodStmt/grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
         .build();
 
     /**

--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -74,6 +74,19 @@
       "type": "keyword",
       "ignore_above": 256
     },
+    "funding": {
+      "type": "nested",
+      "properties": {
+        "agency": {
+          "type": "keyword",
+          "ignore_above": 256
+        },
+        "grantNumber": {
+          "type": "keyword",
+          "ignore_above": 256
+        }
+      }
+    },
     "id": {
       "type": "keyword",
       "ignore_above": 256

--- a/src/main/resources/json/schema/CMMStudy.schema.json
+++ b/src/main/resources/json/schema/CMMStudy.schema.json
@@ -180,6 +180,30 @@
       },
       "description": "An array of File Languages (standardised ISO) for this CMMStudy."
     },
+    "funding": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]{2}$": {
+          "type": "array",
+          "description": "An array of funding formation for this CMMStudy in this given ISO language code",
+          "items": [
+            {
+              "type": "object",
+              "description": "CMMStudy Funding Information",
+              "properties": {
+                "agency": {
+                  "type": "string"
+                },
+                "grantNumber": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        }
+      }
+    },
     "isActive": {
       "type": "boolean",
       "description": "Is the record marked as deleted. If record is deleted this = false.",

--- a/src/test/resources/json/synthetic_compliant_record.json
+++ b/src/test/resources/json/synthetic_compliant_record.json
@@ -110,6 +110,14 @@
     "ee",
     "bb"
   ],
+  "funding":  {
+    "en": [
+      {
+        "agency": "Grant Agency",
+        "grantNumber": "Grant Number"
+      }
+    ]
+  },
   "samplingProcedureFreeTexts": {
     "sv": [
       "Sannolikhetsurval: stratifierat urval",

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -70,6 +70,20 @@
   "dataCollectionPeriodStartdate": "1958-02",
   "fileLanguages": [
   ],
+  "funding": {
+    "en": [
+      {
+        "agency": "GESIS - Leibniz Institute for the Social Sciences",
+        "grantNumber": "Grant Number"
+      }
+    ],
+    "de": [
+      {
+        "agency": "GESIS - Leibniz Institut für Sozialwissenschaften",
+        "grantNumber": "Grant Number"
+      }
+    ]
+  },
   "keywords": {
     "en": [
       {

--- a/src/test/resources/json/synthetic_compliant_record_nesstar.json
+++ b/src/test/resources/json/synthetic_compliant_record_nesstar.json
@@ -191,6 +191,7 @@
     ]
   },
   "fileLanguages": [],
+  "funding": {},
   "typeOfSamplingProcedures": {},
   "universe": {
     "xy": {

--- a/src/test/resources/synthetic_compliant_record.json
+++ b/src/test/resources/synthetic_compliant_record.json
@@ -112,6 +112,14 @@
     "ee",
     "bb"
   ],
+  "funding":  {
+    "en": [
+      {
+        "agency": "Grant Agency",
+        "grantNumber": "Grant Number"
+      }
+    ]
+  },
   "samplingProcedureFreeTexts": {
     "sv": [
       "Sannolikhetsurval: stratifierat urval",

--- a/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
@@ -75,6 +75,7 @@
                 <AuthEnty affiliation="University of Essex. Department of Psychology" xml:lang="en">David Brook</AuthEnty>
               </rspStmt>
               <prodStmt>
+                <grantNo agency="Grant Agency">Grant Number</grantNo>
               </prodStmt>
               <distStmt>
               </distStmt>

--- a/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
@@ -75,6 +75,7 @@
                                 <AuthEnty affiliation="University of Essex. Department of Psychology" xml:lang="en">David Brook</AuthEnty>
                             </rspStmt>
                             <prodStmt>
+                                <grantNo agency="Grant Agency">Grant Number</grantNo>
                             </prodStmt>
                             <distStmt>
                             </distStmt>

--- a/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
+++ b/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
@@ -222,6 +222,18 @@
             <r:Content xml:lang="en">Attitude of the political leadership (members of parliament) in the USA to other nations and problems in world politics.</r:Content>
             <r:Content xml:lang="de">Einstellung der politischen Führungsschicht (Parlamentsmitglieder) in den USA zu anderen Nationen und weltpolitischen Problemen.</r:Content>
         </r:Abstract>
+        <r:FundingInformation>
+            <r:AgencyOrganizationReference>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_Pub1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:TypeOfObject>Organization</r:TypeOfObject>
+            </r:AgencyOrganizationReference>
+            <r:GrantNumber>Grant Number</r:GrantNumber>
+            <r:Description>
+                <r:Content>Description of funding</r:Content>
+            </r:Description>
+        </r:FundingInformation>
         <r:Coverage>
             <r:TopicalCoverage>
                 <r:Agency>de.gesis</r:Agency>

--- a/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
+++ b/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
@@ -218,6 +218,18 @@
             <r:Content xml:lang="en">Attitude of the political leadership (members of parliament) in the USA to other nations and problems in world politics.</r:Content>
             <r:Content xml:lang="de">Einstellung der politischen Führungsschicht (Parlamentsmitglieder) in den USA zu anderen Nationen und weltpolitischen Problemen.</r:Content>
         </r:Abstract>
+        <r:FundingInformation>
+            <r:AgencyOrganizationReference>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_Org_Pub1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:TypeOfObject>Organization</r:TypeOfObject>
+            </r:AgencyOrganizationReference>
+            <r:GrantNumber>Grant Number</r:GrantNumber>
+            <r:Description>
+                <r:Content>Description of funding</r:Content>
+            </r:Description>
+        </r:FundingInformation>
         <r:Coverage>
             <r:TopicalCoverage>
                 <r:Agency>de.gesis</r:Agency>


### PR DESCRIPTION
The funding model consist of two fields:

```json
{
  "agency": "string", // the agency
  "grantNumber": "string" // the grant number
}
```

There can be multiple funding entries per study and language variants are supported.

**Important:** The model documentation at https://github.com/cessda/cessda.cdc.versions/blob/main/DEVELOPER_DOCUMENTATION.md must be updated *before* the PR is merged.

See cessda/cessda.cdc.versions#560 for more information.