### PR TITLE
#652: Add support for parsing DDI 3.x fragment documents

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
@@ -44,7 +44,7 @@ public record CMMStudy(
     @JsonProperty("dataAccessUrl") Map<String, URI> dataAccessUrl,
     @JsonProperty("dataCollectionPeriodStartdate") String dataCollectionPeriodStartdate,
     @JsonProperty("dataCollectionPeriodEnddate") String dataCollectionPeriodEnddate,
-    @JsonProperty("dataCollectionYear") int dataCollectionYear,
+    @JsonProperty("dataCollectionYear") Integer dataCollectionYear,
     @JsonProperty("dataCollectionFreeTexts") Map<String, List<DataCollectionFreeText>> dataCollectionFreeTexts,
     @JsonProperty("fileLanguages") Set<String> fileLanguages,
     @JsonProperty("funding") Map<String, List<Funding>> funding,

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
@@ -44,7 +44,7 @@ public record CMMStudyOfLanguage(
     @JsonProperty("creators") List<String> creators,
     @JsonProperty("dataCollectionPeriodStartdate") String dataCollectionPeriodStartdate,
     @JsonProperty("dataCollectionPeriodEnddate") String dataCollectionPeriodEnddate,
-    @JsonProperty("dataCollectionYear") int dataCollectionYear,
+    @JsonProperty("dataCollectionYear") Integer dataCollectionYear,
     @JsonProperty("dataCollectionFreeTexts") List<DataCollectionFreeText> dataCollectionFreeTexts,
     @JsonProperty("dataAccessFreeTexts") List<String> dataAccessFreeTexts,
     @JsonProperty("dataAccessUrl") URI dataAccessUrl,

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -471,9 +471,13 @@ public class CMMStudyMapper {
     @Value
     public static class DataCollectionPeriod {
         String startDate;
-        int dataCollectionYear;
+        Integer dataCollectionYear;
         String endDate;
         Map<String, List<DataCollectionFreeText>> freeTexts;
+
+        public Optional<Integer> getDataCollectionYear() {
+            return Optional.ofNullable(dataCollectionYear);
+        }
 
         public Optional<String> getStartDate() {
             return Optional.ofNullable(startDate);

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -587,11 +587,6 @@ class ParsingStrategies{
             }
         }
 
-        // Default to 0 if the year cannot be parsed
-        if (year == null) {
-            year = 0;
-        }
-
         var dataCollectionPeriod = new CMMStudyMapper.DataCollectionPeriod(startDate, year, endDate, Collections.emptyMap());
         return new CMMStudyMapper.ParseResults<>(dataCollectionPeriod, parseExceptions);
     }

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -418,6 +418,7 @@ class ParsingStrategies{
 
     /**
      * Parse the universe element. The clusion defaults to I if the source element doesn't specify its inclusivity.
+     *
      * @param elements the elements to parse.
      * @return a {@link Map} the language as the key and a list of universes as the value.
      */
@@ -541,7 +542,7 @@ class ParsingStrategies{
         }
 
         // Parse free texts
-        var freeTexts = XMLMapper.extractMetadataObjectListForEachLang(ParsingStrategies::dataCollFreeTextStrategy).apply(elementList);
+        var freeTexts = extractMetadataObjectListForEachLang(ParsingStrategies::dataCollFreeTextStrategy).apply(elementList);
         dataCollectionPeriodBuilder.freeTexts(freeTexts);
 
         return new CMMStudyMapper.ParseResults<>(
@@ -597,7 +598,7 @@ class ParsingStrategies{
 
         for (var element : elementList) {
             mappingFunction.apply(element).ifPresent(mappedElement ->
-                map.computeIfAbsent(XMLMapper.parseConceptLanguageCode(element), k -> new ArrayList<>()).add(mappedElement)
+                map.computeIfAbsent(parseConceptLanguageCode(element), k -> new ArrayList<>()).add(mappedElement)
             );
         }
 

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -260,21 +260,22 @@ public class RecordXMLParser {
 
             var parseStudyUrlResults = cmmStudyMapper.parseStudyUrl(metadata, xPaths, defaultLangIsoCode);
             builder.studyUrl(parseStudyUrlResults.results());
-            if (!parseStudyUrlResults.exceptions().isEmpty()) {
-                log.warn("[{}] Some URLs in study {} couldn't be parsed: {}",
-                    value(LoggingConstants.REPO_NAME, repository.code()),
-                    value(LoggingConstants.STUDY_ID, studyNumber),
-                    parseStudyUrlResults.exceptions()
-                );
-            }
 
             var parseDataAccessURIResults = cmmStudyMapper.parseDataAccessURI(metadata, xPaths, defaultLangIsoCode);
             builder.dataAccessUrl(parseDataAccessURIResults.results());
-            if (!parseDataAccessURIResults.exceptions().isEmpty()) {
+
+            if (!parseStudyUrlResults.exceptions().isEmpty() || !parseDataAccessURIResults.exceptions().isEmpty()) {
+                // Copy exceptions into a single list
+                var combinedExceptions = new ArrayList<>(
+                    parseStudyUrlResults.exceptions().size() + parseDataAccessURIResults.exceptions().size()
+                );
+                combinedExceptions.addAll(parseDataAccessURIResults.exceptions());
+                combinedExceptions.addAll(parseStudyUrlResults.exceptions());
+
                 log.warn("[{}] Some URLs in study {} couldn't be parsed: {}",
                     value(LoggingConstants.REPO_NAME, repository.code()),
                     value(LoggingConstants.STUDY_ID, studyNumber),
-                    parseDataAccessURIResults.exceptions()
+                    combinedExceptions
                 );
             }
 
@@ -297,9 +298,6 @@ public class RecordXMLParser {
             builder.typeOfModeOfCollections(cmmStudyMapper.parseTypeOfModeOfCollection(metadata, xPaths, defaultLangIsoCode));
 
             var dataCollectionPeriodResults = cmmStudyMapper.parseDataCollectionDates(metadata, xPaths, defaultLangIsoCode);
-            dataCollectionPeriodResults.results().getStartDate().ifPresent(builder::dataCollectionPeriodStartdate);
-            dataCollectionPeriodResults.results().getEndDate().ifPresent(builder::dataCollectionPeriodEnddate);
-            builder.dataCollectionYear(dataCollectionPeriodResults.results().getDataCollectionYear());
             if (!dataCollectionPeriodResults.exceptions().isEmpty()) {
                 // Parsing errors occurred, log here
                 log.warn("[{}] Some dates in study {} couldn't be parsed: {}",
@@ -308,6 +306,9 @@ public class RecordXMLParser {
                     dataCollectionPeriodResults.exceptions()
                 );
             }
+            dataCollectionPeriodResults.results().getStartDate().ifPresent(builder::dataCollectionPeriodStartdate);
+            dataCollectionPeriodResults.results().getEndDate().ifPresent(builder::dataCollectionPeriodEnddate);
+            dataCollectionPeriodResults.results().getDataCollectionYear().ifPresent(builder::dataCollectionYear);
             builder.dataCollectionFreeTexts(dataCollectionPeriodResults.results().getFreeTexts());
 
             try {

--- a/src/main/java/eu/cessda/pasc/oci/parser/ResolvingXMLMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ResolvingXMLMapper.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright © 2017-2024 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.pasc.oci.parser;
+
+import lombok.NonNull;
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * An XML mapper that supports both direct and DDI 3.x references.
+ * If the direct XPath does not resolve the reference XPath is tried.
+ *
+ * @param <T> the return type of the mapping function.
+ */
+public class ResolvingXMLMapper<T> implements XMLMapper<T> {
+    private final String baseXPath;
+    private final String referenceXPath;
+    private final String withinXPath;
+    private final Function<List<Element>, T> mappingFunction;
+
+    /**
+     * Create a new instance of the XML mapper.
+     *
+     * @param baseXPath the direct XPath to the element.
+     * @param referenceXPath the XPath to the reference element.
+     * @param mappingFunction the mapping function.
+     */
+    public ResolvingXMLMapper(String baseXPath, String referenceXPath, Function<List<Element>, T> mappingFunction) {
+        this(baseXPath, referenceXPath, null, mappingFunction);
+    }
+
+    /**
+     * Create a new instance of the XML mapper.
+     *
+     * @param baseXPath the direct XPath to the base element.
+     * @param referenceXPath the XPath to the reference element.
+     * @param withinXPath the XPath to the final element after resolution.
+     * @param mappingFunction the mapping function.
+     */
+    public ResolvingXMLMapper(String baseXPath, String referenceXPath, String withinXPath, Function<List<Element>, T> mappingFunction) {
+        this.baseXPath = baseXPath;
+        this.referenceXPath = referenceXPath;
+        this.withinXPath = withinXPath;
+        this.mappingFunction = mappingFunction;
+    }
+
+    @Override
+    public T resolve(Object context, Namespace... namespace) {
+        // Resolve base or reference
+        XPathExpression<Element> expression = XPathFactory.instance().compile(baseXPath, Filters.element(), null, namespace);
+
+        var elementList = expression.evaluate(context);
+
+        if (elementList.isEmpty()) {
+            // Try resolving the reference XPath
+            XPathExpression<Element> referenceExpression = XPathFactory.instance().compile(referenceXPath, Filters.element(), null, namespace);
+            var referenceElements = referenceExpression.evaluate(context);
+
+            if (!referenceElements.isEmpty()) {
+                elementList = resolveReferences(referenceElements);
+            }
+        }
+
+        if (withinXPath != null) {
+            // Resolve inner element
+            XPathExpression<Element> targetExpression = XPathFactory.instance().compile(withinXPath, Filters.element(), null, namespace);
+            var targetElementList = new ArrayList<Element>();
+            for (var element : elementList) {
+                var targetElement = targetExpression.evaluate(element);
+                targetElementList.addAll(targetElement);
+            }
+
+            return mappingFunction.apply(targetElementList);
+        } else {
+            return mappingFunction.apply(elementList);
+        }
+    }
+
+    private static @NonNull List<Element> resolveReferences(List<Element> referenceElements) {
+        var elementList = new ArrayList<Element>();
+        for (var ref : referenceElements) {
+            var resolvedReference = XMLMapper.resolveReference(ref);
+            resolvedReference.map(ResolvedReference::element).ifPresent(elementList::add);
+        }
+        return elementList;
+    }
+}

--- a/src/main/java/eu/cessda/pasc/oci/parser/SimpleXMLMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/SimpleXMLMapper.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017-2024 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.pasc.oci.parser;
+
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Maps elements found at a specified XPath using a provided mapping function.
+ *
+ * @param <T> the resulting type of the mapping function.
+ */
+class SimpleXMLMapper<T> implements XMLMapper<T> {
+    private final String xPath;
+    private final Function<List<Element>, T> mappingFunction;
+
+    /**
+     * Constructs a new instance of the XMLMapper.
+     *
+     * @param xPath the XPath of the elements to map.
+     * @param mappingFunction the mapping function.
+     */
+    SimpleXMLMapper(String xPath, Function<List<Element>, T> mappingFunction) {
+        this.xPath = xPath;
+        this.mappingFunction = mappingFunction;
+    }
+
+    /**
+     * Resolves the given context object to an instance of T.
+     *
+     * @param context a XPath context to pass to {@link XPathExpression#evaluate(Object)}.
+     * @param namespace the XML namespaces to allow resolution of prefixes.
+     * @return an instance of {@link T}.
+     */
+    @Override
+    public T resolve(Object context, Namespace... namespace) {
+        XPathExpression<Element> expression = XPathFactory.instance().compile(xPath, Filters.element(), null, namespace);
+        var result = expression.evaluate(context);
+        return mappingFunction.apply(result);
+    }
+}

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -102,52 +102,52 @@ public final class XPaths {
             Namespace.getNamespace("s", "ddi:studyunit:3_2")
         })
         // Abstract
-        .abstractXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Abstract/r:Content", parseLanguageContentOfElement(Element::getTextTrim)))
+        .abstractXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Abstract/r:Content", parseLanguageContentOfElement(Element::getTextTrim)))
         // Study title
-        .titleXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Title/r:String", parseLanguageContentOfElement(Element::getTextTrim)))
+        .titleXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Title/r:String", parseLanguageContentOfElement(Element::getTextTrim)))
         // 'Access study' link (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLDocDscrXPath(new XMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLDocDscrXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLStudyDscrXPath(new XMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // Study number/PID
-        .pidStudyXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:InternationalIdentifier", extractMetadataObjectListForEachLang(ParsingStrategies::pidLifecycleStrategy)))
+        .pidStudyXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:InternationalIdentifier", extractMetadataObjectListForEachLang(ParsingStrategies::pidLifecycleStrategy)))
         // Creator/PI
-        .creatorsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Creator", ParsingStrategies::creatorsStrategy))
+        .creatorsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Creator", ParsingStrategies::creatorsStrategy))
         // Terms of data access
-        .dataRestrctnXPath(new XMLMapper<>("//s:StudyUnit[1]/a:Archive/a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
+        .dataRestrctnXPath(new ResolvingXMLMapper<>("//s:StudyUnit[1]/a:Archive", "//s:StudyUnit[1]/r:ArchiveReference", "//a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
         // Data collection period
-        .dataCollectionPeriodsXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:DataCollectionDate", elementList -> getFirstEntry(ParsingStrategies::dataCollectionPeriodsLifecycleStrategy).apply(elementList).orElse(EMPTY_PARSE_RESULTS)))
+        .dataCollectionPeriodsXPath(new ResolvingXMLMapper<>("//s:StudyUnit[1]/d:DataCollection", "//s:StudyUnit[1]/r:DataCollectionReference", "//d:CollectionEvent/d:DataCollectionDate", elementList -> getFirstEntry(ParsingStrategies::dataCollectionPeriodsLifecycleStrategy).apply(elementList).orElse(EMPTY_PARSE_RESULTS)))
         // Publication year
-        .yearOfPubXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:PublicationDate/r:SimpleDate", getFirstEntry(Element::getTextTrim)))
+        .yearOfPubXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:PublicationDate/r:SimpleDate", getFirstEntry(Element::getTextTrim)))
         // Topics
-        .classificationsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Subject", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_2_STRATEGY)))
+        .classificationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Subject", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_2_STRATEGY)))
         // Keywords
-        .keywordsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Keyword", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_2_STRATEGY)))
+        .keywordsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Keyword", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_2_STRATEGY)))
         // Time dimension
-        .typeOfTimeMethodXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .typeOfTimeMethodXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Country
-        .studyAreaCountriesXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:SpatialCoverage/r:GeographicLocationReference", ParsingStrategies::geographicLocationStrategy))
+        .studyAreaCountriesXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:SpatialCoverage/r:GeographicLocationReference", ParsingStrategies::geographicLocationStrategy))
         // Analysis unit
-        .unitTypeXPath(new XMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> analysisUnitStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .unitTypeXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> analysisUnitStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Publisher
-        .publisherXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Publisher/r:PublisherReference", ParsingStrategies::publisherReferenceStrategy))
+        .publisherXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Publisher/r:PublisherReference", ParsingStrategies::publisherReferenceStrategy))
         // Language of data file(s)
-        .fileTxtLanguagesXPath(new XMLMapper<>( "//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Language", XMLMapper::getLanguageFromElements))
+        .fileTxtLanguagesXPath(new ResolvingXMLMapper<>( "//s:StudyUnit[1]/pi:PhysicalInstance",  "//s:StudyUnit[1]/r:PhysicalInstanceReference","//r:Citation/r:Language", XMLMapper::getLanguageFromElements))
         // Language-specific name of file
-        .filenameLanguagesXPath(new XMLMapper<>("//ddi:DDIInstance/g:ResourcePackage/pi:PhysicalInstance/r:Citation/r:Title/r:String", XMLMapper::getLanguagesOfElements))
+        .filenameLanguagesXPath(new ResolvingXMLMapper<>( "//s:StudyUnit[1]/pi:PhysicalInstance",  "//s:StudyUnit[1]/r:PhysicalInstanceReference","//r:Citation/r:Title/r:String", XMLMapper::getLanguagesOfElements))
         // Sampling procedure
-        .samplingXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> samplingProceduresLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .samplingXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> samplingProceduresLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // Data collection mode
-        .typeOfModeOfCollectionXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
+        .typeOfModeOfCollectionXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_2_ATTR_NAMES)))
         // PID of Related publication
-        .relatedPublicationsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
+        .relatedPublicationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
         /// /r:Citation/r:InternationalIdentifier/r:IdentifierContent
         // Study description language
         .recordDefaultLanguage("//ddi:DDIInstance/@xml:lang")
         // Description of population
-        .universeXPath(new XMLMapper<>("//s:StudyUnit[1]/c:ConceptualComponent/c:UniverseScheme/c:Universe", ParsingStrategies::universeLifecycleStrategy))
+        .universeXPath(new ResolvingXMLMapper<>("//s:StudyUnit[1]/c:ConceptualComponent/c:UniverseScheme/c:Universe" ,"//s:StudyUnit[1]/r:UniverseReference", ParsingStrategies::universeLifecycleStrategy))
         // Funding information
-        .fundingXPath(new XMLMapper<>("//s:StudyUnit[1]/r:FundingInformation", ParsingStrategies::fundingLifecycleStrategy))
+        .fundingXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:FundingInformation", ParsingStrategies::fundingLifecycleStrategy))
         .build();
 
     private static final TermVocabAttributeNames DDI_3_3_ATTR_NAMES = new TermVocabAttributeNames("controlledVocabularyName", "controlledVocabularyURN");
@@ -169,19 +169,19 @@ public final class XPaths {
             Namespace.getNamespace("s", "ddi:studyunit:3_3")
         })
         // PID of Related publication
-        .withRelatedPublicationsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:OtherMaterialScheme/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
+        .withRelatedPublicationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:OtherMaterialScheme/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
         // Topics
-        .withClassificationsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Subject", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_3_STRATEGY)))
+        .withClassificationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Subject", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_3_STRATEGY)))
         // Keywords
-        .withKeywordsXPath(new XMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Keyword", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_3_STRATEGY)))
+        .withKeywordsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Keyword", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_3_STRATEGY)))
         // Time dimension
-        .withTypeOfTimeMethodXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> ParsingStrategies.typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)))
+        .withTypeOfTimeMethodXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:TimeMethod", (List<Element> elementList) -> ParsingStrategies.typeOfTimeMethodLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)))
         // Analysis unit
-        .withUnitTypeXPath(new XMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> ParsingStrategies.analysisUnitStrategy(elementList, DDI_3_3_ATTR_NAMES)))
+        .withUnitTypeXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:AnalysisUnit", (List<Element> elementList) -> ParsingStrategies.analysisUnitStrategy(elementList, DDI_3_3_ATTR_NAMES)))
         // Sampling procedure
-        .withSamplingXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> ParsingStrategies.samplingProceduresLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)))
+        .withSamplingXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:Methodology/d:SamplingProcedure", (List<Element> elementList) -> ParsingStrategies.samplingProceduresLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)))
         // Data collection mode
-        .withTypeOfModeOfCollectionXPath(new XMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> ParsingStrategies.typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)));
+        .withTypeOfModeOfCollectionXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/d:DataCollection/d:CollectionEvent/d:ModeOfCollection", (List<Element> elementList) -> ParsingStrategies.typeOfModeOfCollectionLifecycleStrategy(elementList, DDI_3_3_ATTR_NAMES)));
 
 
     Optional<XMLMapper<Map<String, String>>> getParTitleXPath() {
@@ -213,57 +213,57 @@ public final class XPaths {
     public static final XPaths DDI_2_5_XPATHS = XPaths.builder()
         .namespace(new Namespace[]{ Namespace.getNamespace("ddi", "ddi:codebook:2_5") })
         // Abstract
-        .abstractXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract", parseLanguageContentOfElement(Element::getTextTrim, (a, b) -> a + "<br>" + b)))
+        .abstractXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract", parseLanguageContentOfElement(Element::getTextTrim, (a, b) -> a + "<br>" + b)))
         // Study title
-        .titleXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl", parseLanguageContentOfElement(Element::getTextTrim)))
+        .titleXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl", parseLanguageContentOfElement(Element::getTextTrim)))
         // Study title (in additional languages)
-        .parTitleXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
+        .parTitleXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
         // 'Access study' link
-        .studyURLDocDscrXPath(new XMLMapper<>("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLDocDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // URL of the study description page at the SP website
-        .studyURLStudyDscrXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // Study number/PID
-        .pidStudyXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy)))
+        .pidStudyXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy)))
         // Creator
-        .creatorsXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty", extractMetadataObjectListForEachLang(ParsingStrategies::creatorStrategy)))
+        .creatorsXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty", extractMetadataObjectListForEachLang(ParsingStrategies::creatorStrategy)))
         // Terms of data access
-        .dataAccessUrlXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:specPerm", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .dataAccessUrlXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:specPerm", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // Terms of data access
-        .dataRestrctnXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
+        .dataRestrctnXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
         // Data collection period
-        .dataCollectionPeriodsXPath(new XMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate", ParsingStrategies::dataCollectionPeriodsStrategy))
+        .dataCollectionPeriodsXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate", ParsingStrategies::dataCollectionPeriodsStrategy))
         // Publication year
-        .yearOfPubXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate[1]", getFirstEntry(ParsingStrategies::dateStrategy)))
+        .yearOfPubXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate[1]", getFirstEntry(ParsingStrategies::dateStrategy)))
         // Topics
-        .classificationsXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
+        .classificationsXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
         // Keywords
-        .keywordsXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
+        .keywordsXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
         // Time dimension
-        .typeOfTimeMethodXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
+        .typeOfTimeMethodXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
         // Country
-        .studyAreaCountriesXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation", extractMetadataObjectListForEachLang(ParsingStrategies::countryStrategy)))
+        .studyAreaCountriesXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation", extractMetadataObjectListForEachLang(ParsingStrategies::countryStrategy)))
         // Analysis unit
-        .unitTypeXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
+        .unitTypeXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
         // Publisher name/Contributor
-        .publisherXPath(new XMLMapper<>("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:prodStmt/ddi:producer", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
+        .publisherXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:prodStmt/ddi:producer", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
         // Publisher
-        .distributorXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
+        .distributorXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
         // Language of data file(s)
-        .fileTxtLanguagesXPath(new XMLMapper<>( "//ddi:codeBook/ddi:fileDscr/ddi:fileTxt", XMLMapper::getLanguagesOfElements))
+        .fileTxtLanguagesXPath(new SimpleXMLMapper<>( "//ddi:codeBook/ddi:fileDscr/ddi:fileTxt", XMLMapper::getLanguagesOfElements))
         // Language-specific name of file
-        .filenameLanguagesXPath(new XMLMapper<>("//ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName", XMLMapper::getLanguagesOfElements))
+        .filenameLanguagesXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName", XMLMapper::getLanguagesOfElements))
         // Sampling procedure
-        .samplingXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
+        .samplingXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
         // Data collection mode
-        .typeOfModeOfCollectionXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
+        .typeOfModeOfCollectionXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
         // Related publication
-        .relatedPublicationsXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:othrStdyMat/ddi:relPubl", extractMetadataObjectListForEachLang(ParsingStrategies::relatedPublicationsStrategy)))
+        .relatedPublicationsXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:othrStdyMat/ddi:relPubl", extractMetadataObjectListForEachLang(ParsingStrategies::relatedPublicationsStrategy)))
         // Study description language
         .recordDefaultLanguage("//ddi:codeBook/@xml:lang")
         // Description of population
-        .universeXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
+        .universeXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
         // Funding information
-        .fundingXPath(new XMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:prodStmt/ddi:grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
+        .fundingXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:prodStmt/ddi:grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
         .build();
 
     /**
@@ -273,31 +273,31 @@ public final class XPaths {
         .namespace(new Namespace[]{ Namespace.getNamespace("ddi", "http://www.icpsr.umich.edu/DDI") })
         .recordDefaultLanguage("//ddi:codeBook/@xml-lang") // Nesstar with "-"
         // Closest for Nesstar based on CMM mapping doc but the above existing one for ddi2.5 seems to be present in Nesstar
-        .yearOfPubXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/distStmt/distDate[1]", getFirstEntry(ParsingStrategies::dateStrategy)))
-        .abstractXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/abstract", parseLanguageContentOfElement(Element::getTextTrim, (a, b) -> a + "<br>" + b)))
-        .titleXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/titl", parseLanguageContentOfElement(Element::getTextTrim)))
-        .parTitleXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
-        .studyURLStudyDscrXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/setAvail/accsPlac", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .yearOfPubXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/distStmt/distDate[1]", getFirstEntry(ParsingStrategies::dateStrategy)))
+        .abstractXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/abstract", parseLanguageContentOfElement(Element::getTextTrim, (a, b) -> a + "<br>" + b)))
+        .titleXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/titl", parseLanguageContentOfElement(Element::getTextTrim)))
+        .parTitleXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
+        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/setAvail/accsPlac", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // PID path missing for most nesstar repos. Available in FORS but:
         //  -No agency
         //  -Only element freetext value.
-        .pidStudyXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy))) // use @agency instead?
-        .creatorsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty", extractMetadataObjectListForEachLang(ParsingStrategies::creatorStrategy)))
-        .dataRestrctnXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/useStmt/restrctn", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
-        .dataCollectionPeriodsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate", ParsingStrategies::dataCollectionPeriodsStrategy))
-        .classificationsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
-        .keywordsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/subject/keyword", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
-        .typeOfTimeMethodXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/timeMeth", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
-        .studyAreaCountriesXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation", extractMetadataObjectListForEachLang(ParsingStrategies::countryStrategy)))
-        .unitTypeXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit", extractMetadataObjectListForEachLang(element -> termVocabAttributeStrategy(element, true))))
-        .publisherXPath(new XMLMapper<>("//ddi:codeBook/docDscr/citation/prodStmt/producer", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
-        .distributorXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/distStmt/distrbtr", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
-        .samplingXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/sampProc", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
-        .typeOfModeOfCollectionXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/collMode",  elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
-        .relatedPublicationsXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/othrStdyMat/relPubl", extractMetadataObjectListForEachLang(ParsingStrategies::relatedPublicationsStrategy)))
-        .universeXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
+        .pidStudyXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy))) // use @agency instead?
+        .creatorsXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty", extractMetadataObjectListForEachLang(ParsingStrategies::creatorStrategy)))
+        .dataRestrctnXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/useStmt/restrctn", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
+        .dataCollectionPeriodsXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate", ParsingStrategies::dataCollectionPeriodsStrategy))
+        .classificationsXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
+        .keywordsXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/subject/keyword", extractMetadataObjectListForEachLang(element -> ParsingStrategies.termVocabAttributeStrategy(element, false))))
+        .typeOfTimeMethodXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/timeMeth", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
+        .studyAreaCountriesXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation", extractMetadataObjectListForEachLang(ParsingStrategies::countryStrategy)))
+        .unitTypeXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit", extractMetadataObjectListForEachLang(element -> termVocabAttributeStrategy(element, true))))
+        .publisherXPath(new SimpleXMLMapper<>("//ddi:codeBook/docDscr/citation/prodStmt/producer", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
+        .distributorXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/distStmt/distrbtr", parseLanguageContentOfElement(ParsingStrategies::publisherStrategy)))
+        .samplingXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/sampProc", elementList -> ParsingStrategies.conceptStrategy(elementList, ParsingStrategies::samplingTermVocabAttributeStrategy)))
+        .typeOfModeOfCollectionXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/method/dataColl/collMode", elementList -> ParsingStrategies.conceptStrategy(elementList, e -> ParsingStrategies.termVocabAttributeStrategy(e, true))))
+        .relatedPublicationsXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/othrStdyMat/relPubl", extractMetadataObjectListForEachLang(ParsingStrategies::relatedPublicationsStrategy)))
+        .universeXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/sumDscr/universe", extractMetadataObjectListForEachLang(ParsingStrategies::universeStrategy)))
         // Funding information
-        .fundingXPath(new XMLMapper<>("//ddi:codeBook/stdyDscr/citation/prodStmt/grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
+        .fundingXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/prodStmt/grantNo", extractMetadataObjectListForEachLang(ParsingStrategies::fundingStrategy)))
         .build();
 
     /**

--- a/src/test/java/eu/cessda/pasc/oci/parser/ParserTestUtilities.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/ParserTestUtilities.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017-2024 CESSDA ERIC (support@cessda.eu)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.cessda.pasc.oci.parser;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.fge.jackson.JsonLoader;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+import eu.cessda.pasc.oci.models.cmmstudy.CMMStudy;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.fail;
+
+public class ParserTestUtilities {
+    private final ObjectMapper objectMapper;
+
+    public ParserTestUtilities(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException {
+        var jsonString = objectMapper.writeValueAsString(record);
+
+        var jsonNodeRecord = JsonLoader.fromString(jsonString);
+        var schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:/json/schema/CMMStudy.schema.json");
+
+        var validate = schema.validate(jsonNodeRecord);
+        if (!validate.isSuccess()) {
+            fail("Validation not successful: " + validate);
+        }
+    }
+}

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
@@ -15,18 +15,13 @@
  */
 package eu.cessda.pasc.oci.parser;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
-import com.github.fge.jsonschema.main.JsonSchema;
-import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import eu.cessda.pasc.oci.ResourceHandler;
 import eu.cessda.pasc.oci.configurations.Repo;
 import eu.cessda.pasc.oci.exception.IndexerException;
+import eu.cessda.pasc.oci.exception.XMLParseException;
 import eu.cessda.pasc.oci.mock.data.ReposTestData;
-import eu.cessda.pasc.oci.models.cmmstudy.CMMStudy;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.junit.Test;
@@ -36,7 +31,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.TimeZone;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
@@ -50,6 +44,7 @@ public class RecordXMLParserDDI3Test {
 
     private final Repo repo = ReposTestData.getUKDSRepo();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ParserTestUtilities utils = new ParserTestUtilities(objectMapper);
 
     // Class under test
     private final CMMStudyMapper cmmStudyMapper = new CMMStudyMapper();
@@ -61,69 +56,35 @@ public class RecordXMLParserDDI3Test {
 
     @Test
     public void shouldReturnValidCMMStudyRecordFromAFullyComplaintCmmDdi32Record() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
-        // Given
-        var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_ddi_3.json");
-        var recordXML = ResourceHandler.getResource("xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml");
-
-        // When
-        var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
-
-        then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
-
-        String actualJson = objectMapper.writeValueAsString(result.get(0));
-
-        // Check if the JSON generated differs from the expected source
-        assertEquals(expectedJson, actualJson, true);
+        testParsing("xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml", "json/synthetic_compliant_record_ddi_3.json");
     }
 
     @Test
     public void shouldReturnValidCMMStudyRecordFromAFullyComplaintCmmDdi33Record() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
         // Given
-        var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_ddi_3.json");
-        var recordXML = ResourceHandler.getResource("xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml");
-
-        // When
-        var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
-
-        then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
-
-        String actualJson = objectMapper.writeValueAsString(result.get(0));
-
-        // Check if the JSON generated differs from the expected source
-        assertEquals(expectedJson, actualJson, true);
+        testParsing("xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml", "json/synthetic_compliant_record_ddi_3.json");
     }
 
     @Test
     public void shouldReturnValidCMMStudyRecordFromAFullyFragmentRecord() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
         // Given
-        var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_ddi_3_fragments.json");
-        var recordXML = ResourceHandler.getResource("xml/ddi_3_3/compliant_fragments_cmm_ddi_3_3.xml");
+        testParsing("xml/ddi_3_3/compliant_fragments_cmm_ddi_3_3.xml", "json/synthetic_compliant_record_ddi_3_fragments.json");
+    }
+
+    private void testParsing(String sourceXML, String expectedJSON) throws IOException, XMLParseException, URISyntaxException, ProcessingException, JSONException {
+        // Given
+        var recordXML = ResourceHandler.getResource(sourceXML);
+        var expectedJson = ResourceHandler.getResourceAsString(expectedJSON);
 
         // When
         var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
 
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
 
         String actualJson = objectMapper.writeValueAsString(result.get(0));
 
         // Check if the JSON generated differs from the expected source
         assertEquals(expectedJson, actualJson, true);
-    }
-
-    private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException {
-        String jsonString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(record);
-        log.debug("RETRIEVED STUDY JSON: \n" + jsonString);
-
-
-        JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:/json/schema/CMMStudy.schema.json");
-        JsonNode jsonNodeRecord = JsonLoader.fromString(jsonString);
-
-        ProcessingReport validate = schema.validate(jsonNodeRecord);
-        if (!validate.isSuccess()) {
-            fail("Validation not successful : " + validate);
-        }
     }
 }

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserDDI3Test.java
@@ -95,6 +95,24 @@ public class RecordXMLParserDDI3Test {
         assertEquals(expectedJson, actualJson, true);
     }
 
+    @Test
+    public void shouldReturnValidCMMStudyRecordFromAFullyFragmentRecord() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+        // Given
+        var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_ddi_3_fragments.json");
+        var recordXML = ResourceHandler.getResource("xml/ddi_3_3/compliant_fragments_cmm_ddi_3_3.xml");
+
+        // When
+        var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
+
+        then(result).hasSize(1);
+        validateCMMStudyResultAgainstSchema(result.get(0));
+
+        String actualJson = objectMapper.writeValueAsString(result.get(0));
+
+        // Check if the JSON generated differs from the expected source
+        assertEquals(expectedJson, actualJson, true);
+    }
+
     private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException {
         String jsonString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(record);
         log.debug("RETRIEVED STUDY JSON: \n" + jsonString);

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserNesstarTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserNesstarTest.java
@@ -16,9 +16,7 @@
 package eu.cessda.pasc.oci.parser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import eu.cessda.pasc.oci.ResourceHandler;
 import eu.cessda.pasc.oci.configurations.Repo;
 import eu.cessda.pasc.oci.exception.IndexerException;
@@ -33,7 +31,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.HashMap;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
@@ -44,7 +41,7 @@ public class RecordXMLParserNesstarTest {
 
     private final CMMStudyMapper cmmStudyMapper = new CMMStudyMapper();
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final ParserTestUtilities utils = new ParserTestUtilities(objectMapper);
 
     private static HashMap<String, String> getAbstractFixture() {
         var expectedAbstract = new HashMap<String, String>();
@@ -73,7 +70,7 @@ public class RecordXMLParserNesstarTest {
 
         // Then
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
 
         var actualJson = objectMapper.writeValueAsString(result.get(0));
         var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_nesstar.json");
@@ -93,7 +90,7 @@ public class RecordXMLParserNesstarTest {
 
         // Then
         then(record).hasSize(1);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test
@@ -106,9 +103,9 @@ public class RecordXMLParserNesstarTest {
         // When
         var record = new RecordXMLParser(cmmStudyMapper).getRecord(nesstarRepo, Path.of(recordXML.toURI()));
         then(record).hasSize(1);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
         var jsonString = objectMapper.writeValueAsString(record.get(0));
-        var actualTree = mapper.readTree(jsonString);
+        var actualTree = objectMapper.readTree(jsonString);
 
         // Then
         then(actualTree.get("dataCollectionPeriodStartdate").asText()).isEqualTo("2004-09-16");
@@ -147,7 +144,7 @@ public class RecordXMLParserNesstarTest {
         then(record).hasSize(1);
         then(record.get(0).abstractField().size()).isEqualTo(4);
         then(record.get(0).abstractField()).isEqualTo(expectedAbstract);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test // https://github.com/cessda/cessda.cdc.versions/issues/135
@@ -166,7 +163,7 @@ public class RecordXMLParserNesstarTest {
         then(record).hasSize(1);
         then(record.get(0).titleStudy().size()).isEqualTo(2);
         then(record.get(0).titleStudy()).isEqualTo(expectedTitle);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test()
@@ -207,28 +204,16 @@ public class RecordXMLParserNesstarTest {
 
         // Then
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
         assertThatCmmRequiredFieldsAreExtracted(result.get(0));
-    }
-
-    private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException {
-        var jsonString = objectMapper.writeValueAsString(record);
-
-        var jsonNodeRecord = JsonLoader.fromString(jsonString);
-        var schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:/json/schema/CMMStudy.schema.json");
-
-        var validate = schema.validate(jsonNodeRecord);
-        if (!validate.isSuccess()) {
-            fail("Validation not successful: " + validate);
-        }
     }
 
     private void assertThatCmmRequiredFieldsAreExtracted(CMMStudy record) throws JSONException, IOException {
 
         var jsonString = objectMapper.writeValueAsString(record);
         var expectedJson = ResourceHandler.getResourceAsString("json/synthetic_compliant_record_nesstar.json");
-        final var actualTree = mapper.readTree(jsonString);
-        final var expectedTree = mapper.readTree(expectedJson);
+        final var actualTree = objectMapper.readTree(jsonString);
+        final var expectedTree = objectMapper.readTree(expectedJson);
 
         // CMM Model Schema required fields
         assertEquals(expectedTree.get("abstract").toString(), actualTree.get("abstract").toString(), true);
@@ -259,7 +244,7 @@ public class RecordXMLParserNesstarTest {
         var result = new RecordXMLParser(cmmStudyMapper).getRecord(langRepo, Path.of(recordXML.toURI()));
 
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
 
         // Assert the language is as expected
         Assert.assertNotNull(result.get(0).titleStudy().get("zz"));

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
@@ -17,11 +17,7 @@ package eu.cessda.pasc.oci.parser;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.fge.jackson.JsonLoader;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
-import com.github.fge.jsonschema.main.JsonSchema;
-import com.github.fge.jsonschema.main.JsonSchemaFactory;
 import eu.cessda.pasc.oci.ResourceHandler;
 import eu.cessda.pasc.oci.configurations.Repo;
 import eu.cessda.pasc.oci.exception.IndexerException;
@@ -30,7 +26,6 @@ import eu.cessda.pasc.oci.mock.data.ReposTestData;
 import eu.cessda.pasc.oci.models.cmmstudy.CMMStudy;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,7 +37,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TimeZone;
 
-import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
@@ -56,6 +50,7 @@ public class RecordXMLParserTest {
 
     private final Repo repo = ReposTestData.getUKDSRepo();
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ParserTestUtilities utils = new ParserTestUtilities(objectMapper);
 
     // Class under test
     private final CMMStudyMapper cmmStudyMapper = new CMMStudyMapper();
@@ -75,7 +70,7 @@ public class RecordXMLParserTest {
         var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
 
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
 
         String actualJson = objectMapper.writeValueAsString(result.get(0));
 
@@ -109,7 +104,7 @@ public class RecordXMLParserTest {
     }
 
     @Test
-    public void shouldReturnValidCMMStudyRecordFromOaiPmhDDI2_5MetadataRecord() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldReturnValidCMMStudyRecordFromOaiPmhDDI2_5MetadataRecord() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         // Given
         var recordXML = ResourceHandler.getResource("xml/ddi_2_5/ddi_record_1683.xml");
@@ -119,12 +114,12 @@ public class RecordXMLParserTest {
 
         // Then
         then(record).hasSize(1);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test
     @SuppressWarnings("PreferJavaTimeOverload")
-    public void shouldOnlyExtractSingleDateAsStartDateForRecordsWithASingleDateAttr() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldOnlyExtractSingleDateAsStartDateForRecordsWithASingleDateAttr() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         // Given
         var recordXML = ResourceHandler.getResource("xml/ddi_2_5/ddi_record_1683.xml");
@@ -132,7 +127,7 @@ public class RecordXMLParserTest {
         // When
         var record = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
         then(record).hasSize(1);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
         final ObjectMapper mapper = new ObjectMapper();
         String jsonString = objectMapper.writeValueAsString(record.get(0));
         final JsonNode actualTree = mapper.readTree(jsonString);
@@ -159,7 +154,7 @@ public class RecordXMLParserTest {
 
     @Test
     @SuppressWarnings("PreferJavaTimeOverload")
-    public void shouldReturnCMMStudyRecordWithRepeatedAbstractConcatenated() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldReturnCMMStudyRecordWithRepeatedAbstractConcatenated() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         Map<String, String> expectedAbstract = new HashMap<>();
         expectedAbstract.put("de", "de de");
@@ -174,12 +169,12 @@ public class RecordXMLParserTest {
         then(record).hasSize(1);
         then(record.get(0).abstractField().size()).isEqualTo(3);
         then(record.get(0).abstractField()).isEqualTo(expectedAbstract);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test // https://github.com/cessda/cessda.cdc.versions/issues/135
     @SuppressWarnings("PreferJavaTimeOverload")
-    public void shouldReturnCMMStudyRecordWithOutParTitleWhenThereIsALangDifferentFromDefault() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldReturnCMMStudyRecordWithOutParTitleWhenThereIsALangDifferentFromDefault() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         Map<String, String> expectedTitle = new HashMap<>();
         expectedTitle.put("en", "Machinery of Government, 1976-1977");
@@ -194,7 +189,7 @@ public class RecordXMLParserTest {
         then(record).hasSize(1);
         then(record.get(0).titleStudy().size()).isEqualTo(3);
         then(record.get(0).titleStudy()).isEqualTo(expectedTitle);
-        validateCMMStudyResultAgainstSchema(record.get(0));
+        utils.validateCMMStudyResultAgainstSchema(record.get(0));
     }
 
     @Test()
@@ -233,7 +228,7 @@ public class RecordXMLParserTest {
         var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
 
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
         assertThatCmmRequiredFieldsAreExtracted(result.get(0));
     }
 
@@ -250,20 +245,6 @@ public class RecordXMLParserTest {
         then(result.get(0).dataCollectionYear()).isNull();
     }
 
-    private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException, JSONException {
-        String jsonString = objectMapper.writeValueAsString(record);
-        JSONObject json = new JSONObject(jsonString);
-        log.debug("RETRIEVED STUDY JSON: \n" + json.toString(4));
-
-        JsonNode jsonNodeRecord = JsonLoader.fromString(jsonString);
-        final JsonSchema schema = JsonSchemaFactory.byDefault().getJsonSchema("resource:/json/schema/CMMStudy.schema.json");
-
-        ProcessingReport validate = schema.validate(jsonNodeRecord);
-        if (!validate.isSuccess()) {
-            fail("Validation not successful : " + validate);
-        }
-    }
-
     private void assertThatCmmRequiredFieldsAreExtracted(CMMStudy record) throws IOException, JSONException {
         var expectedJson = ResourceHandler.getResource("json/ddi_record_ukds_example_extracted.json");
         final JsonNode actualTree = objectMapper.valueToTree(record);
@@ -278,7 +259,7 @@ public class RecordXMLParserTest {
     }
 
     @Test
-    public void shouldOverrideGlobalLanguageDefaultIfAPerRepositoryOverrideIsSpecified() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldOverrideGlobalLanguageDefaultIfAPerRepositoryOverrideIsSpecified() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         var repository = ReposTestData.getUKDSLanguageOverrideRepository();
 
@@ -289,7 +270,7 @@ public class RecordXMLParserTest {
         var result = new RecordXMLParser(cmmStudyMapper).getRecord(repository, Path.of(recordXML.toURI()));
 
         then(result).hasSize(1);
-        validateCMMStudyResultAgainstSchema(result.get(0));
+        utils.validateCMMStudyResultAgainstSchema(result.get(0));
 
         // Assert the language is as expected
         Assert.assertNotNull(result.get(0).titleStudy().get("zz"));
@@ -307,7 +288,7 @@ public class RecordXMLParserTest {
         then(result).hasSize(2);
 
         for (var study : result) {
-            validateCMMStudyResultAgainstSchema(study);
+            utils.validateCMMStudyResultAgainstSchema(study);
         }
 
         var actualJson = objectMapper.writeValueAsString(result.get(0));

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
@@ -237,6 +237,19 @@ public class RecordXMLParserTest {
         assertThatCmmRequiredFieldsAreExtracted(result.get(0));
     }
 
+    @Test
+    public void shouldHaveNullDataCollectionYearWhenRequiredFieldsAreNotPreset() throws FileNotFoundException, URISyntaxException, XMLParseException {
+
+        // Given
+        var recordXML = ResourceHandler.getResource("xml/ddi_2_5/ddi_record_ukds_example.xml");
+
+        // When
+        var result = new RecordXMLParser(cmmStudyMapper).getRecord(repo, Path.of(recordXML.toURI()));
+
+        then(result).hasSize(1);
+        then(result.get(0).dataCollectionYear()).isNull();
+    }
+
     private void validateCMMStudyResultAgainstSchema(CMMStudy record) throws IOException, ProcessingException, JSONException {
         String jsonString = objectMapper.writeValueAsString(record);
         JSONObject json = new JSONObject(jsonString);

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -68,7 +68,9 @@
   "dataCollectionYear": 1958,
   "dataCollectionPeriodEnddate": "1958-04",
   "dataCollectionPeriodStartdate": "1958-02",
-  "fileLanguages": [
+  "fileLanguages":[
+    "de",
+    "en"
   ],
   "funding": {
     "en": [

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3_fragments.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3_fragments.json
@@ -1,0 +1,100 @@
+{
+  "abstract": {
+    "no": "ADVANCE 2 bygger på funnene fra den opprinnelige ADVANCE-studien (2013-2018) som etablerte et internasjonalt samarbeid av forskere og helsepersonell som adresserer vold i hjemmet. Fokuset er på å støtte kvinner som lever med vold i hjemmet under graviditet i Nepal, en viktig årsak til dårlige graviditetsutfall. Forekomst av vold i hjemmet er høyest i lavinntektsland, men de vitenskapelige bevis for intervensjoner i svangerskapsomsorgen er mest mangelfull i disse sammenhengene. Studien sikter på å rette opp denne mangelen i fire komplementære arbeidspakker (delstudier), ved å bruke tverrfaglige forskningsmetoder. Målet er å gjøre det mulig for svangerskapsomsorgsleverandører i Nepal å effektivt identifisere og hjelpe gravide kvinner som lever med vold i hjemmet. Dette dataarkivet er for den innledende fasen (første arbeidspakke) av prosjektet, der kliniske fortester utføres for å tilpasse seg kulturelt, og for å validere en språklig relevant versjon av Abuse Assessment Screen (AAS) spesielt for rutinemessig klinisk bruk i Nepal.Denne versjonen kalles  the Nepalese Abuse Assessment Screen (N-AAS).\n\nAngående variablene merket 'Retest': I studien ble påliteligheten til et spørreskjema vurdert ved hjelp av en test-retest-analyse. Deltakerne fullførte det samme spørreskjemaet på to forskjellige tidspunkter, noe som tillot forskerne å vurdere de samme variablene to ganger - først ved det opprinnelige tidspunktet (T1 eller 'Test') og igjen senere (T2 eller 'Retest'). Denne metoden er beskrevet i detalj i tidsskriftartikkelen som er knyttet til disse dataene.\n\nFor å evaluere presisjonen av de 7 spørsmålene som ble validert i denne studien (kalt Nepalese-Abuse Assessment Screen eller N-AAS), ble deltakernes svar sammenlignet med de samme spørsmålene administrert via dataassistert intervju og gullstandarden, som er en tradisjonell ansikt-til-ansikt intervju med deltakere, utført av en intervjuer.\n\nI Data4-datafilen finner man variabelen \"Expert_category\" med forskjellige typer eksperter som har gjennomgått og gitt tilbakemelding på spørsmålene om skjermbildet for vurdering av overgrep i Nepal (N-AAS):\n- Internasjonale eksperter = fagpersoner med ekspertise innen vold i hjemmet eller relaterte felt fra ulike internasjonale organisasjoner. De deltok i Delphi-runder under studien for å vurdere og gi tilbakemelding på N-AAS.\n- Nasjonale eksperter = en gruppe nasjonale fagpersoner som sykepleiere, psykologer, forskere og klinikere basert i Nepal som gjennomgikk og evaluerte N-AAS under Delphi-metoden. Tallene (1, 2 osv.) representerer ulike nasjonale eksperter/forskjellige personer.\n- Brukereksperter = en gruppe gravide som deltok i kognitive intervjuer, som gir tilbakemelding på N-AAS basert på egne erfaringer. Disse kvinnene vurderte spørsmålene våre for relevans, forståelighet og sensitivitet.\n\nSpørsmålene merket med 'Relevant,' 'Understandable/Clear', og 'Sensitive' ble vurdert av eksperter ved å bruke en fempunkts Likert-skala:\n- Relevans ('Relevant'): Ekspertpanelene vurderte hvert spørsmål basert på dets betydning og relevans for å måle vold i hjemmet. En score på 0 indikerte at spørsmålet var irrelevant, mens en score på 4 indikerte at det var svært relevant.\n- Forståelighet/Klarhet ('Understandable/Clear'): Ekspertene vurderte om ordlyden i hvert spørsmål var tydelig og lett å forstå. En score på 0 betydde at spørsmålet var uforståelig, mens en score på 4 betydde at det var lett forståelig.\n- Sensitivitet ('Sensitive'): Ekspertene evaluerte følsomhetsnivået for hvert spørsmål, spesielt i sammenheng med det kulturelle miljøet i Nepal. En score på 0 indikerte at spørsmålet var høysensitivt, mens en score på 4 indikerte at det var ikke-sensitivt.",
+    "en": "ADVANCE 2 builds on the accomplishments of the original ADVANCE study (2013-2018), which established an international collaboration of researchers and health providers addressing the field of domestic violence. The focus is on supporting women living with domestic violence in pregnancy in Nepal, an important cause of poor pregnancy outcomes. Domestic violence is highest in low-income countries, yet the scientific evidence for interventions in antenatal care is most lacking in these contexts. The study aims to remedy this gap in four complementary work packages (sub-studies), employing interdisciplinary research methods. The goal is to enable antenatal care providers in Nepal to identify effectively and assist pregnant women living with domestic violence. This data archive is for the initial phase (first work package) of the project, where clinical pretesting is carried out to adapt culturally, and to validate a linguistically relevant version of the Abuse Assessment Screen (AAS) specifically for routine clinical use in Nepal. This version is called the Nepalese Abuse Assessment Screen (N-AAS).\n\nConcerning the variables labeled 'Retest': In the study, the reliability of a questionnaire was assessed using a test-retest analysis. Participants completed the same questionnaire at two different time points, allowing the researchers to assess the same variables twice - first at the initial time point (T1 or 'Test') and again later (T2 or 'Retest'). This methodology is detailed in the journal article associated with this data.\n\nTo evaluate the precision of the 7 questions validated in this study (called the Nepalese-Abuse Assessment Screen or N-AAS),  participants' answers were compared to the same questions administered via computer-assisted interview and the gold standard, which is a traditional face-to-face interview with participants, conducted by an interviewer.\n\nIn the Data4 datafile the variable 'Expert_category' includes different types of experts who reviewed and provided feedback on the Nepalese Abuse Assessment Screen (N-AAS) questions:\n- International experts = professionals with expertise in domestic violence or related fields from various international organizations. They participated in Delphi rounds during the study to assess and provide feedback on the N-AAS.\n- National experts = a group of national professionals such as nurses, psychologists, researchers, and clinicians based in Nepal who reviewed and evaluated the N-AAS during the Delphi method. The numbers (1, 2, etc.) represent different national experts/different people.\n- User experts = a group of pregnant women who participated in cognitive interviews, providing feedback on the N-AAS based on their own experiences. These women assessed our questions for relevance, understandability, and sensitivity.\n\nThe questions marked with 'Relevant,' 'Understandable/Clear', and 'Sensitive' were assessed by experts using a five-point Likert scale as follows:\n- Relevance: The expert panels rated each question based on its importance and pertinence for measuring domestic violence. A score of 0 indicated the question was irrelevant, while a score of 4 indicated it was highly relevant.\n- Understandability/Clarity: The experts assessed whether the wording of each question was clear and easy to understand. A score of 0 meant the question was non-understandable, whereas a score of 4 meant it was easily understandable.\n- Sensitivity: The experts evaluated the level of sensitivity of each question, particularly in the context of the cultural environment of Nepal. A score of 0 indicated the question was highly sensitive, while a score of 4 indicated it was non-sensitive."
+  },
+  "classifications": {
+    "en": [
+      {
+        "vocab": "",
+        "vocabUri": "",
+        "id": "",
+        "term": "Health.PublicHealth"
+      },
+      {
+        "vocab": "",
+        "vocabUri": "",
+        "id": "",
+        "term": "Health.ReproductiveHealth"
+      }
+    ]
+  },
+  "creators": {
+    "no": [
+      "NTNU"
+    ],
+    "en": [
+      "NTNU"
+    ]
+  },
+  "dataAccessFreeTexts": {},
+  "dataAccessUrl": {},
+  "dataCollectionPeriodStartdate": "2021-12-01",
+  "dataCollectionPeriodEnddate": "2022-11-30",
+  "dataCollectionYear": 2021,
+  "dataCollectionFreeTexts": {},
+  "fileLanguages": [
+    "no",
+    "en"
+  ],
+  "funding": {
+    "no": [
+      {
+        "grantNumber": "301525",
+        "agency": "Norges forskningsråd"
+      }
+    ],
+    "en": [
+      {
+        "grantNumber": "301525",
+        "agency": "The Research Council of Norway"
+      }
+    ]
+  },
+  "keywords": {},
+  "pidStudies": {
+    "en": [
+      {
+        "agency": "DOI",
+        "pid": "https://doi.org/10.18712/NSD-NSD3174-V1"
+      }
+    ]
+  },
+  "publicationYear": "2024-05-03T00:00:00Z",
+  "publisher": {
+    "no": {
+      "abbr": "",
+      "publisher": "Sikt - Kunnskapssektorens tjenesteleverandør"
+    },
+    "en": {
+      "abbr": "",
+      "publisher": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+    }
+  },
+  "relatedPublications": {},
+  "samplingProcedureFreeTexts": {},
+  "studyAreaCountries": {},
+  "studyNumber": "no.nsd:39c1f667-17c2-475b-9333-846f59666e32:16",
+  "studyUrl": {},
+  "typeOfModeOfCollections": {},
+  "titleStudy": {
+    "no": "Addressing Domestic Violence in Antenatal Care Environments 2 (ADVANCE 2)",
+    "en": "Addressing Domestic Violence in Antenatal Care Environments 2 (ADVANCE 2)"
+  },
+  "typeOfTimeMethods": {},
+  "typeOfSamplingProcedures": {},
+  "unitTypes": {
+    "en": [
+      {
+        "vocab": "",
+        "vocabUri": "",
+        "id": "",
+        "term": "Individual"
+      }
+    ]
+  },
+  "universe": {},
+  "lastModified": "2024-05-03T13:14:02.3620880Z",
+  "studyXmlSourceUrl": "https://oai.ukdataservice.ac.uk:8443/oai/provider?verb=GetRecord&identifier=no.nsd%3A39c1f667-17c2-475b-9333-846f59666e32%3A16&metadataPrefix=ddi",
+  "repositoryUrl": "/oai/request"
+}

--- a/src/test/resources/xml/ddi_3_3/compliant_fragments_cmm_ddi_3_3.xml
+++ b/src/test/resources/xml/ddi_3_3/compliant_fragments_cmm_ddi_3_3.xml
@@ -1,0 +1,1037 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type='text/xsl' href='/oai/oai-pmh.xsl'?>
+<oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/">
+    <oai:responseDate>2024-05-06T06:33:38Z</oai:responseDate>
+    <oai:request verb="GetRecord">/oai/request</oai:request>
+    <oai:GetRecord>
+        <oai:record>
+            <oai:header>
+                <oai:identifier>no.nsd:39c1f667-17c2-475b-9333-846f59666e32:16</oai:identifier>
+                <oai:datestamp>2024-05-03T13:14:02.3620880Z</oai:datestamp>
+                <oai:setSpec>30ea0200-7121-4f01-8d21-a931a182b86d</oai:setSpec>
+            </oai:header>
+            <oai:metadata>
+                <ddi:FragmentInstance xmlns:ddi="ddi:instance:3_3"
+                                      xmlns:r="ddi:reusable:3_3"
+                                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                      xsi:schemaLocation="ddi:instance:3_3 http://www.ddialliance.org/Specification/DDI-Lifecycle/3.3/XMLSchema/instance.xsd">
+                    <ddi:TopLevelReference>
+                        <r:Agency>no.nsd</r:Agency>
+                        <r:ID>39c1f667-17c2-475b-9333-846f59666e32</r:ID>
+                        <r:Version>16</r:Version>
+                        <r:TypeOfObject>StudyUnit</r:TypeOfObject>
+                    </ddi:TopLevelReference>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2024-04-29T13:36:36.8270814Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:f0478985-f894-4294-a400-c3551ff87c56:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>f0478985-f894-4294-a400-c3551ff87c56</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn Dhulikhel Hospital-Kathmandu University School of Medical Sciences, Kathmandu Medical College, Linnaeus University og John Hopkins University School of Nursing</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">Linnaeus University</r:String>
+                                    <r:String xml:lang="no">Linnéuniversitetet</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2024-04-29T13:36:36.8270814Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:be253f98-7aa0-4720-af65-2fb27d2257e3:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>be253f98-7aa0-4720-af65-2fb27d2257e3</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn Dhulikhel Hospital-Kathmandu University School of Medical Sciences, Kathmandu Medical College, Linnaeus University og John Hopkins University School of Nursing</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">Kathmandu Medical College</r:String>
+                                    <r:String xml:lang="no">Kathmandu Medical College</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2024-04-29T13:36:36.8270814Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:09dfdcc2-e650-4a3e-83e1-e850c98f8ed8:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>09dfdcc2-e650-4a3e-83e1-e850c98f8ed8</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn Dhulikhel Hospital-Kathmandu University School of Medical Sciences, Kathmandu Medical College, Linnaeus University og John Hopkins University School of Nursing</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">John Hopkins University School of Nursing</r:String>
+                                    <r:String xml:lang="no">John Hopkins University School of Nursing</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2024-04-29T13:36:36.8270814Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:53052e71-eb74-49f5-808c-2026512a1763:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>53052e71-eb74-49f5-808c-2026512a1763</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn Dhulikhel Hospital-Kathmandu University School of Medical Sciences, Kathmandu Medical College, Linnaeus University og John Hopkins University School of Nursing</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">Dhulikhel Hospital-Kathmandu University School of Medical Sciences</r:String>
+                                    <r:String xml:lang="no">Dhulikhel Hospital-Kathmandu University School of Medical Sciences</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2021-05-07T21:04:23.9815098Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:ebadc6e6-7994-4844-9822-646fbf5cd224:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>ebadc6e6-7994-4844-9822-646fbf5cd224</r:ID>
+                            <r:Version>1</r:Version>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">OsloMet</r:String>
+                                    <r:String xml:lang="no">OsloMet</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2023-06-26T07:48:33.9842933Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:1581d2af-6d25-4a21-87bc-f5705779092a:3</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>1581d2af-6d25-4a21-87bc-f5705779092a</r:ID>
+                            <r:Version>3</r:Version>
+                            <r:VersionResponsibility>SIKT\mja047</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Oppdatert Sikt til versjon 3 for å forsøke å "av-deprecate"</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">Sikt - Norwegian Agency for Shared Services in Education and Research</r:String>
+                                    <r:String xml:lang="no">Sikt - Kunnskapssektorens tjenesteleverandør</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Universe isUniversallyUnique="true" versionDate="2024-04-29T13:53:58.9438971Z" xmlns="ddi:conceptualcomponent:3_3">
+                            <r:URN>urn:ddi:no.nsd:7fc27ed5-9094-4181-9717-cb228812f326:2</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>7fc27ed5-9094-4181-9717-cb228812f326</r:ID>
+                            <r:Version>2</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Feilretting.</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <UniverseName>
+                                <r:String xml:lang="en">Pregnant women attending the Outpatient Department (OPD) of Obstetrics and Gynecology departments at two collaborating hospitals in Nepal.</r:String>
+                                <r:String xml:lang="no">Gravide kvinner som deltar i poliklinisk avdeling (OPD) for obstetrikk og gynekologi ved to samarbeidende sykehus i Nepal.</r:String>
+                            </UniverseName>
+                            <r:Label>
+                                <r:Content xml:lang="en">Pregnant women attending the Outpatient Department (OPD) of Obstetrics and Gynecology departments at two collaborating hospitals in Nepal.</r:Content>
+                                <r:Content xml:lang="no">Gravide kvinner som deltar i poliklinisk avdeling (OPD) for obstetrikk og gynekologi ved to samarbeidende sykehus i Nepal.</r:Content>
+                            </r:Label>
+                        </Universe>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <DataCollection isUniversallyUnique="true" versionDate="2024-05-03T13:06:51.4209387Z" xmlns="ddi:datacollection:3_3">
+                            <r:URN>urn:ddi:no.nsd:c60e5fba-6b5d-4061-9dd1-792bf681c603:4</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>c60e5fba-6b5d-4061-9dd1-792bf681c603</r:ID>
+                            <r:Version>4</r:Version>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>extension:ProcessingEventReferences</r:AttributeKey>
+                                <r:AttributeValue>["urn:ddi:no.nsd:eb71ff35-b507-4601-8b1c-2a5aba9c7604:1"]</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <r:Label>
+                                <r:Content xml:lang="no">1363</r:Content>
+                            </r:Label>
+                            <MethodologyReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>4a5f3c0a-cee4-453d-bf23-757c621086dd</r:ID>
+                                <r:Version>2</r:Version>
+                                <r:TypeOfObject>DataCollectionMethodology</r:TypeOfObject>
+                            </MethodologyReference>
+                            <CollectionEvent isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:019b9c6a-bd4e-4dac-adbe-2d2b6a607d73:4</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>019b9c6a-bd4e-4dac-adbe-2d2b6a607d73</r:ID>
+                                <r:Version>4</r:Version>
+                                <DataCollectionDate>
+                                    <r:StartDate>2021-12-01</r:StartDate>
+                                    <r:EndDate>2022-11-30</r:EndDate>
+                                </DataCollectionDate>
+                                <ModeOfCollection isUniversallyUnique="true">
+                                    <r:URN>urn:ddi:no.nsd:41f0f382-85e7-4e9b-a4e4-c269c4dd01ad:4</r:URN>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>41f0f382-85e7-4e9b-a4e4-c269c4dd01ad</r:ID>
+                                    <r:Version>4</r:Version>
+                                    <TypeOfModeOfCollection controlledVocabularyID="00f4b65f-fcfd-4fa7-a113-27acb13d3b1e" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">Interview.FaceToFace.CAPIorCAMI</TypeOfModeOfCollection>
+                                </ModeOfCollection>
+                                <ModeOfCollection isUniversallyUnique="true">
+                                    <r:URN>urn:ddi:no.nsd:6b7c86d0-63c0-4818-9b62-fbab35976899:4</r:URN>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>6b7c86d0-63c0-4818-9b62-fbab35976899</r:ID>
+                                    <r:Version>4</r:Version>
+                                    <TypeOfModeOfCollection controlledVocabularyID="00f4b65f-fcfd-4fa7-a113-27acb13d3b1e" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">Interview.FaceToFace</TypeOfModeOfCollection>
+                                </ModeOfCollection>
+                            </CollectionEvent>
+                        </DataCollection>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Methodology isUniversallyUnique="true" versionDate="2024-04-29T13:46:44.999184Z" xmlns="ddi:datacollection:3_3">
+                            <r:URN>urn:ddi:no.nsd:4a5f3c0a-cee4-453d-bf23-757c621086dd:2</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>4a5f3c0a-cee4-453d-bf23-757c621086dd</r:ID>
+                            <r:Version>2</r:Version>
+                            <r:VersionResponsibility>SIKT\jolei</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Dokumentert på studienivå.</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <TimeMethod isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:0fc1fc99-5aa1-4193-b081-ae81d21ea392:2</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>0fc1fc99-5aa1-4193-b081-ae81d21ea392</r:ID>
+                                <r:Version>2</r:Version>
+                                <TypeOfTimeMethod controlledVocabularyID="5247ed79-600e-431c-ad3b-b1743df6295c" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">CrossSection</TypeOfTimeMethod>
+                            </TimeMethod>
+                            <SamplingProcedure isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:3b9c9957-fe2d-4689-9ac9-4ba7add6cbfd:2</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>3b9c9957-fe2d-4689-9ac9-4ba7add6cbfd</r:ID>
+                                <r:Version>2</r:Version>
+                                <TypeOfSamplingProcedure controlledVocabularyID="60c23367-cf0c-41d3-b885-4af6ad800ec8" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">MixedProbabilityNonprobability</TypeOfSamplingProcedure>
+                                <r:Description>
+                                    <r:Content xml:lang="en">The partisipating women were referred to the data collection site by nursing staff following their registration. The purpose of the data collection was to validate a culturally-sensitive, Nepalese language clinical screening instrument for identifying women experiencing domestic violence. The screening instrument aims to address the unique sociocultural context of Nepal, as existing screening tools have primarily been developed in high-income countries.</r:Content>
+                                    <r:Content xml:lang="no">De deltagende kvinnene ble henvist til datainnsamlingsstedet av sykepleiepersonalet etter deres registrering. Formålet med datainnsamlingen var å validere et kulturelt sensitivt, nepalsk språklig klinisk screeninginstrument for å identifisere kvinner som opplever vold i hjemmet. Screeninginstrumentet har som mål å ta hensyn til Nepals unike sosiokulturelle kontekst, ettersom eksisterende screeningverktøy hovedsakelig har blitt utviklet i høyinntektsland.</r:Content>
+                                </r:Description>
+                            </SamplingProcedure>
+                        </Methodology>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <VariableGroup isUniversallyUnique="true" versionDate="2024-05-03T12:40:44.6023468Z" xmlns="ddi:logicalproduct:3_3">
+                            <r:URN>urn:ddi:no.nsd:fd4d2cfa-3eea-4a7f-bf2b-645f89e72903:2</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>fd4d2cfa-3eea-4a7f-bf2b-645f89e72903</r:ID>
+                            <r:Version>2</r:Version>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn variabelgrupper</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <r:Label>
+                                <r:Content xml:lang="en">Data1 Validation Test Retest</r:Content>
+                            </r:Label>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>8fb4d6df-149f-44ef-ab63-baf461a0b645</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>0dfcd1c2-a850-4767-b1c9-252507f50676</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>bbb6ac57-dda1-46fe-8606-ccec1cc51707</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>a6ae4676-5045-41a7-a102-8716fed437a5</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>162ad198-ab67-425b-bdc3-9aef58ae03ee</r:ID>
+                                <r:Version>2</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>99b86f4d-e082-483c-892e-9bbf797782a5</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>b31ca375-6e51-40aa-8168-0fcdaa7d55f4</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>a6533862-4f4e-42c9-8b5a-bba7f3824727</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>8b692c34-ca59-4108-a9a8-b8ca80059dc5</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                        </VariableGroup>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <DataRelationship isUniversallyUnique="true" versionDate="2024-05-03T12:14:49.5005405Z" xmlns="ddi:logicalproduct:3_3">
+                            <r:URN>urn:ddi:no.nsd:a6d07d30-6640-48ed-afa7-12504040c726:3</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>a6d07d30-6640-48ed-afa7-12504040c726</r:ID>
+                            <r:Version>3</r:Version>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <DataRelationshipName>
+                                <r:String xml:lang="en">Data 3_validation_Testvsgoldstandard</r:String>
+                            </DataRelationshipName>
+                            <LogicalRecord isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:6cd57a0f-7217-4088-b88a-819df0bdbdc2:3</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>6cd57a0f-7217-4088-b88a-819df0bdbdc2</r:ID>
+                                <r:Version>3</r:Version>
+                                <LogicalRecordName>
+                                    <r:String xml:lang="en">Data 3_validation_Testvsgoldstandard</r:String>
+                                </LogicalRecordName>
+                                <VariablesInRecord>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>240d85f5-5c23-4842-9b61-15ce6064a7a7</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>ba778177-92f4-40fa-958b-af87d52c6153</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>0d46233d-59aa-4ea2-868a-b09719131335</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>afb543d8-6344-40d0-ba6b-995208f77d99</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>70cadf7e-590e-4424-8a8a-ca53118fe4fe</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>2b6c4d52-7b12-46d8-80d1-c96e4853efb5</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>f50ca5ca-805e-4ded-85f4-f3d6a30607e0</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>0c7a43dc-6516-43b7-9f7f-86cb2d2d54db</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>22985c72-2b04-4674-affb-184489d1c249</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>e024ae2e-bd94-4322-9fa1-6158ffc41aad</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>5b61bed7-e1c8-4e56-bd14-e0b620e94f6d</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>0aa0d949-ea11-4476-9a75-4906d7c2532a</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>4b15bc4b-3e1c-4f77-8af1-b8558c3dcb89</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>1c84b206-db97-430d-ae9d-b8a084209e9f</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>a1d2a346-6de7-44cd-933f-07214b3a509f</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                </VariablesInRecord>
+                            </LogicalRecord>
+                        </DataRelationship>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <VariableGroup isUniversallyUnique="true" versionDate="2024-05-03T12:40:44.6023468Z" xmlns="ddi:logicalproduct:3_3">
+                            <r:URN>urn:ddi:no.nsd:21a73385-3262-4491-a4e3-f05d14c7da43:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>21a73385-3262-4491-a4e3-f05d14c7da43</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn variabelgrupper</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <r:Label>
+                                <r:Content xml:lang="en">Data 3 Validation test vs gold standard</r:Content>
+                            </r:Label>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>9efe2ee4-33e7-424a-b3c7-880dc6fc0dbe</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                            <VariableGroupReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>1d3b2f51-2e8a-4d9c-bdda-a85a37f53ab0</r:ID>
+                                <r:Version>1</r:Version>
+                                <r:TypeOfObject>VariableGroup</r:TypeOfObject>
+                            </VariableGroupReference>
+                        </VariableGroup>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <DataRelationship isUniversallyUnique="true" versionDate="2024-05-03T12:14:49.5005405Z" xmlns="ddi:logicalproduct:3_3">
+                            <r:URN>urn:ddi:no.nsd:97f63354-b417-4522-95fb-85731c1d58d1:3</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>97f63354-b417-4522-95fb-85731c1d58d1</r:ID>
+                            <r:Version>3</r:Version>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <DataRelationshipName>
+                                <r:String xml:lang="en">Data 4_validation_Delphi</r:String>
+                            </DataRelationshipName>
+                            <LogicalRecord isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:69bcd10f-aebc-4aaa-89be-b5f67e9a23c9:3</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>69bcd10f-aebc-4aaa-89be-b5f67e9a23c9</r:ID>
+                                <r:Version>3</r:Version>
+                                <LogicalRecordName>
+                                    <r:String xml:lang="en">Data 4_validation_Delphi</r:String>
+                                </LogicalRecordName>
+                                <VariablesInRecord>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>c0b1908a-3388-4a66-a241-48ab3db002a0</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>fd456371-7b3d-485a-9421-c954501af128</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>55a89c40-0c85-4cf0-9e0e-5c9c99a18293</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>b90c1520-6597-4746-b553-9ed4a9c03f7d</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>da86beb1-7b39-4789-9b00-811547e51791</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>119eb95f-3a39-4d3b-bde0-8f7c5664e197</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>df1f81ae-00cc-4b8c-9f7b-2dc2643ae6bc</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>9997a33d-b7e0-4d27-b39a-b27c83e53be2</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>ff2dff66-4157-4021-b854-db089e6ae525</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>6c00184f-2b48-421f-990a-72efc15d66cd</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>7a7eb41b-d051-4a7c-aa7f-59119b1c0a1c</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>2f75c244-e90e-4416-ba63-8059e7c9b97d</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>c5d64932-46c4-4e1b-b80b-49e849d35712</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>b08dfc3c-3ea6-4d99-b8f7-9b28a52c8d8a</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>4ec5e616-ed8f-48f7-977a-104c30b27943</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>6ae47c38-1a95-428a-87f7-1cd9597eaafb</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>f852a7b6-96b0-4e66-b8ef-847339401e07</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>ad8b8ffc-342c-4ce3-9ac9-ba1736f29ab4</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>adfc7166-3884-45ba-9d04-26984b66292a</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>fa0b5c28-85b8-46f7-bbbd-215df860bb3c</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>f705e936-37d2-43bb-b29c-d4b54ec15241</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                    <VariableUsedReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>41aca9f0-aedc-414b-a324-99d133486e0d</r:ID>
+                                        <r:Version>2</r:Version>
+                                        <r:TypeOfObject>Variable</r:TypeOfObject>
+                                    </VariableUsedReference>
+                                </VariablesInRecord>
+                            </LogicalRecord>
+                        </DataRelationship>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <ProcessingEvent isUniversallyUnique="true" versionDate="2024-04-26T13:34:15.209794Z" xmlns="ddi:datacollection:3_3">
+                            <r:URN>urn:ddi:no.nsd:eb71ff35-b507-4601-8b1c-2a5aba9c7604:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>eb71ff35-b507-4601-8b1c-2a5aba9c7604</r:ID>
+                            <r:Version>1</r:Version>
+                            <r:VersionResponsibility>e997a8ab-87f9-4396-be02-3a6fb978986c</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="en">Commit</r:String>
+                                    <r:String xml:lang="no">Commit</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <r:Label>
+                                <r:Content xml:lang="no">1363</r:Content>
+                            </r:Label>
+                            <ControlOperation />
+                            <CleaningOperation />
+                        </ProcessingEvent>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2021-05-07T21:04:23.9815098Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:e7ffa38f-91c2-41be-8c70-5e8ed24e5081:1</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>e7ffa38f-91c2-41be-8c70-5e8ed24e5081</r:ID>
+                            <r:Version>1</r:Version>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">University of South-Eastern Norway</r:String>
+                                    <r:String xml:lang="no">Universitetet i Sørøst-Norge</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <StudyUnit isUniversallyUnique="true" versionDate="2024-05-03T13:12:27.8426901Z" xmlns="ddi:studyunit:3_3">
+                            <r:URN>urn:ddi:no.nsd:39c1f667-17c2-475b-9333-846f59666e32:16</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>39c1f667-17c2-475b-9333-846f59666e32</r:ID>
+                            <r:Version>16</r:Version>
+                            <r:UserID typeOfUserID="ArchiveID">1363</r:UserID>
+                            <r:UserID typeOfUserID="StudyNumber">NSD3174</r:UserID>
+                            <r:UserID typeOfUserID="StudyVersion">1.0</r:UserID>
+                            <r:UserID typeOfUserID="DOI">https://doi.org/10.18712/NSD-NSD3174-V1</r:UserID>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>extension:CustomField</r:AttributeKey>
+                                <r:AttributeValue>{"Title":{"en-US":"","no":"Dataspråk"},"Description":{},"ValueType":0,"DefinedTypeId":"d0357d5c-6ba9-4e66-ad7c-9f466f177abb","HasValue":true,"RelationshipTargetType":"00000000-0000-0000-0000-000000000000","StringValue":"en","MultilingualStringValue":{},"BooleanValue":false,"HasDefinedType":true,"DisplayLabel":"Dataspråk"}</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>extension:CustomField</r:AttributeKey>
+                                <r:AttributeValue>{"Title":{"en-US":"","no":"Annet"},"Description":{},"ValueType":1,"DefinedTypeId":"c05e597c-dc06-4f10-898b-5a3396db1a2a","HasValue":true,"RelationshipTargetType":"00000000-0000-0000-0000-000000000000","MultilingualStringValue":{"no":"","en":"This is a de-identified dataset from a phase of clinical pre-testing for a validation study in Nepal."},"BooleanValue":false,"HasDefinedType":true,"DisplayLabel":"Annet"}</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>extension:CustomField</r:AttributeKey>
+                                <r:AttributeValue>{"Title":{"en-US":"","no":"Persondata"},"Description":{},"ValueType":0,"DefinedTypeId":"4d77a21b-d4fb-42bd-8a06-cc0b1cadb598","HasValue":true,"RelationshipTargetType":"00000000-0000-0000-0000-000000000000","StringValue":"FALSE","MultilingualStringValue":{},"BooleanValue":false,"HasDefinedType":true,"DisplayLabel":"Persondata"}</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>extension:CustomField</r:AttributeKey>
+                                <r:AttributeValue>{"Title":{"no":"Interne notater"},"Description":{},"ValueType":0,"HasValue":true,"RelationshipTargetType":"00000000-0000-0000-0000-000000000000","StringValue":"Datasett mottatt: 05.04.2024, ny versjon mottatt 26.04.2024.\r\n\r\nDokumentert på studienivå (bør ses over når mer dokumentasjon finnes... DateTime brukt for temporal coverage pga. bugg i colectica) (29.04.24 JAL).\r\n\r\nImportert alle 4 datafiler, importert metadata input sheet og lagt variabler i variabelgrupper (03.02.24 KS)\r\n","MultilingualStringValue":{},"BooleanValue":false,"HasDefinedType":false,"DisplayLabel":"Interne notater"}</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <r:Citation>
+                                <r:Title>
+                                    <r:String xml:lang="en">Addressing Domestic Violence in Antenatal Care Environments 2 (ADVANCE 2)</r:String>
+                                    <r:String xml:lang="no">Addressing Domestic Violence in Antenatal Care Environments 2 (ADVANCE 2)</r:String>
+                                </r:Title>
+                                <r:Creator>
+                                    <r:CreatorName>
+                                        <r:String xml:lang="en">NTNU</r:String>
+                                        <r:String xml:lang="no">NTNU</r:String>
+                                    </r:CreatorName>
+                                    <r:CreatorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>92c44fbd-1206-4af6-b8bc-5b2f954a6958</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:CreatorReference>
+                                </r:Creator>
+                                <r:Publisher>
+                                    <r:PublisherName>
+                                        <r:String xml:lang="en">Sikt</r:String>
+                                        <r:String xml:lang="no">Sikt</r:String>
+                                    </r:PublisherName>
+                                    <r:PublisherReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>1581d2af-6d25-4a21-87bc-f5705779092a</r:ID>
+                                        <r:Version>3</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:PublisherReference>
+                                </r:Publisher>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="NTNU">
+                                        <r:String xml:lang="en">Infanti, Jennifer</r:String>
+                                        <r:String xml:lang="no">Infanti, Jennifer</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>92c44fbd-1206-4af6-b8bc-5b2f954a6958</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="USN">
+                                        <r:String xml:lang="en">Lukasse, Mirjam</r:String>
+                                        <r:String xml:lang="no">Lukasse, Mirjam</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>e7ffa38f-91c2-41be-8c70-5e8ed24e5081</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="NTNU">
+                                        <r:String xml:lang="en">Schei, Berit</r:String>
+                                        <r:String xml:lang="no">Schei, Berit</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>92c44fbd-1206-4af6-b8bc-5b2f954a6958</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Dhulikhel Hospital-Kathmandu University School of Medical Sciences">
+                                        <r:String xml:lang="en">Pun, Kunta Devi</r:String>
+                                        <r:String xml:lang="no">Pun, Kunta Devi</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>53052e71-eb74-49f5-808c-2026512a1763</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Dhulikhel Hospital-Kathmandu University School of Medical Sciences">
+                                        <r:String xml:lang="en">Koju, Rajendra</r:String>
+                                        <r:String xml:lang="no">Koju, Rajendra</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>53052e71-eb74-49f5-808c-2026512a1763</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Kathmandu Medical College">
+                                        <r:String xml:lang="en">Joshi, Sunil Kumar</r:String>
+                                        <r:String xml:lang="no">Joshi, Sunil Kumar</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectLeader</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>be253f98-7aa0-4720-af65-2fb27d2257e3</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Linnaeus University">
+                                        <r:String xml:lang="en">Swahnberg, Katarina</r:String>
+                                        <r:String xml:lang="no">Swahnberg, Katarina</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ProjectOperations.ProjectMember</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>f0478985-f894-4294-a400-c3551ff87c56</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="John Hopkins University School of Nursing">
+                                        <r:String xml:lang="en">Campbell, Jacquelyn</r:String>
+                                        <r:String xml:lang="no">Campbell, Jacquelyn</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ResearchGroup</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>09dfdcc2-e650-4a3e-83e1-e850c98f8ed8</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Kathmandu Medical College">
+                                        <r:String xml:lang="en">Rishal, Poonam</r:String>
+                                        <r:String xml:lang="no">Rishal, Poonam</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ResearchGroup</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>be253f98-7aa0-4720-af65-2fb27d2257e3</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Oslo Metropolitan University">
+                                        <r:String xml:lang="en">Henriksen, Lena</r:String>
+                                        <r:String xml:lang="no">Henriksen, Lena</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">ResearchGroup</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>ebadc6e6-7994-4844-9822-646fbf5cd224</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Kathmandu Medical College">
+                                        <r:String xml:lang="en">Manandhar, Pratibha</r:String>
+                                        <r:String xml:lang="no">Manandhar, Pratibha</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">DataCollection</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>be253f98-7aa0-4720-af65-2fb27d2257e3</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:Contributor>
+                                    <r:ContributorName affiliation="Dhulikhel Hospital-Kathmandu University School of Medical Sciences">
+                                        <r:String xml:lang="en">Chalise, Pratibha</r:String>
+                                        <r:String xml:lang="no">Chalise, Pratibha</r:String>
+                                    </r:ContributorName>
+                                    <r:ContributorRole controlledVocabularyID="69b03d1d-53cc-4df1-8b03-db96fd2907f6" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">DataCollection</r:ContributorRole>
+                                    <r:ContributorReference>
+                                        <r:Agency>no.nsd</r:Agency>
+                                        <r:ID>53052e71-eb74-49f5-808c-2026512a1763</r:ID>
+                                        <r:Version>1</r:Version>
+                                        <r:TypeOfObject>Organization</r:TypeOfObject>
+                                    </r:ContributorReference>
+                                </r:Contributor>
+                                <r:PublicationDate>
+                                    <r:SimpleDate>2024-05-03T00:00:00Z</r:SimpleDate>
+                                </r:PublicationDate>
+                                <r:InternationalIdentifier>
+                                    <r:IdentifierContent>https://doi.org/10.18712/NSD-NSD3174-V1</r:IdentifierContent>
+                                    <r:ManagingAgency>DOI</r:ManagingAgency>
+                                </r:InternationalIdentifier>
+                            </r:Citation>
+                            <r:Abstract>
+                                <r:Content xml:lang="en">ADVANCE 2 builds on the accomplishments of the original ADVANCE study (2013-2018), which established an international collaboration of researchers and health providers addressing the field of domestic violence. The focus is on supporting women living with domestic violence in pregnancy in Nepal, an important cause of poor pregnancy outcomes. Domestic violence is highest in low-income countries, yet the scientific evidence for interventions in antenatal care is most lacking in these contexts. The study aims to remedy this gap in four complementary work packages (sub-studies), employing interdisciplinary research methods. The goal is to enable antenatal care providers in Nepal to identify effectively and assist pregnant women living with domestic violence. This data archive is for the initial phase (first work package) of the project, where clinical pretesting is carried out to adapt culturally, and to validate a linguistically relevant version of the Abuse Assessment Screen (AAS) specifically for routine clinical use in Nepal. This version is called the Nepalese Abuse Assessment Screen (N-AAS).
+
+Concerning the variables labeled 'Retest': In the study, the reliability of a questionnaire was assessed using a test-retest analysis. Participants completed the same questionnaire at two different time points, allowing the researchers to assess the same variables twice - first at the initial time point (T1 or 'Test') and again later (T2 or 'Retest'). This methodology is detailed in the journal article associated with this data.
+
+To evaluate the precision of the 7 questions validated in this study (called the Nepalese-Abuse Assessment Screen or N-AAS),  participants' answers were compared to the same questions administered via computer-assisted interview and the gold standard, which is a traditional face-to-face interview with participants, conducted by an interviewer.
+
+In the Data4 datafile the variable 'Expert_category' includes different types of experts who reviewed and provided feedback on the Nepalese Abuse Assessment Screen (N-AAS) questions:
+- International experts = professionals with expertise in domestic violence or related fields from various international organizations. They participated in Delphi rounds during the study to assess and provide feedback on the N-AAS.
+- National experts = a group of national professionals such as nurses, psychologists, researchers, and clinicians based in Nepal who reviewed and evaluated the N-AAS during the Delphi method. The numbers (1, 2, etc.) represent different national experts/different people.
+- User experts = a group of pregnant women who participated in cognitive interviews, providing feedback on the N-AAS based on their own experiences. These women assessed our questions for relevance, understandability, and sensitivity.
+
+The questions marked with 'Relevant,' 'Understandable/Clear', and 'Sensitive' were assessed by experts using a five-point Likert scale as follows:
+- Relevance: The expert panels rated each question based on its importance and pertinence for measuring domestic violence. A score of 0 indicated the question was irrelevant, while a score of 4 indicated it was highly relevant.
+- Understandability/Clarity: The experts assessed whether the wording of each question was clear and easy to understand. A score of 0 meant the question was non-understandable, whereas a score of 4 meant it was easily understandable.
+- Sensitivity: The experts evaluated the level of sensitivity of each question, particularly in the context of the cultural environment of Nepal. A score of 0 indicated the question was highly sensitive, while a score of 4 indicated it was non-sensitive.</r:Content>
+                                <r:Content xml:lang="no">ADVANCE 2 bygger på funnene fra den opprinnelige ADVANCE-studien (2013-2018) som etablerte et internasjonalt samarbeid av forskere og helsepersonell som adresserer vold i hjemmet. Fokuset er på å støtte kvinner som lever med vold i hjemmet under graviditet i Nepal, en viktig årsak til dårlige graviditetsutfall. Forekomst av vold i hjemmet er høyest i lavinntektsland, men de vitenskapelige bevis for intervensjoner i svangerskapsomsorgen er mest mangelfull i disse sammenhengene. Studien sikter på å rette opp denne mangelen i fire komplementære arbeidspakker (delstudier), ved å bruke tverrfaglige forskningsmetoder. Målet er å gjøre det mulig for svangerskapsomsorgsleverandører i Nepal å effektivt identifisere og hjelpe gravide kvinner som lever med vold i hjemmet. Dette dataarkivet er for den innledende fasen (første arbeidspakke) av prosjektet, der kliniske fortester utføres for å tilpasse seg kulturelt, og for å validere en språklig relevant versjon av Abuse Assessment Screen (AAS) spesielt for rutinemessig klinisk bruk i Nepal.Denne versjonen kalles  the Nepalese Abuse Assessment Screen (N-AAS).
+
+Angående variablene merket 'Retest': I studien ble påliteligheten til et spørreskjema vurdert ved hjelp av en test-retest-analyse. Deltakerne fullførte det samme spørreskjemaet på to forskjellige tidspunkter, noe som tillot forskerne å vurdere de samme variablene to ganger - først ved det opprinnelige tidspunktet (T1 eller 'Test') og igjen senere (T2 eller 'Retest'). Denne metoden er beskrevet i detalj i tidsskriftartikkelen som er knyttet til disse dataene.
+
+For å evaluere presisjonen av de 7 spørsmålene som ble validert i denne studien (kalt Nepalese-Abuse Assessment Screen eller N-AAS), ble deltakernes svar sammenlignet med de samme spørsmålene administrert via dataassistert intervju og gullstandarden, som er en tradisjonell ansikt-til-ansikt intervju med deltakere, utført av en intervjuer.
+
+I Data4-datafilen finner man variabelen "Expert_category" med forskjellige typer eksperter som har gjennomgått og gitt tilbakemelding på spørsmålene om skjermbildet for vurdering av overgrep i Nepal (N-AAS):
+- Internasjonale eksperter = fagpersoner med ekspertise innen vold i hjemmet eller relaterte felt fra ulike internasjonale organisasjoner. De deltok i Delphi-runder under studien for å vurdere og gi tilbakemelding på N-AAS.
+- Nasjonale eksperter = en gruppe nasjonale fagpersoner som sykepleiere, psykologer, forskere og klinikere basert i Nepal som gjennomgikk og evaluerte N-AAS under Delphi-metoden. Tallene (1, 2 osv.) representerer ulike nasjonale eksperter/forskjellige personer.
+- Brukereksperter = en gruppe gravide som deltok i kognitive intervjuer, som gir tilbakemelding på N-AAS basert på egne erfaringer. Disse kvinnene vurderte spørsmålene våre for relevans, forståelighet og sensitivitet.
+
+Spørsmålene merket med 'Relevant,' 'Understandable/Clear', og 'Sensitive' ble vurdert av eksperter ved å bruke en fempunkts Likert-skala:
+- Relevans ('Relevant'): Ekspertpanelene vurderte hvert spørsmål basert på dets betydning og relevans for å måle vold i hjemmet. En score på 0 indikerte at spørsmålet var irrelevant, mens en score på 4 indikerte at det var svært relevant.
+- Forståelighet/Klarhet ('Understandable/Clear'): Ekspertene vurderte om ordlyden i hvert spørsmål var tydelig og lett å forstå. En score på 0 betydde at spørsmålet var uforståelig, mens en score på 4 betydde at det var lett forståelig.
+- Sensitivitet ('Sensitive'): Ekspertene evaluerte følsomhetsnivået for hvert spørsmål, spesielt i sammenheng med det kulturelle miljøet i Nepal. En score på 0 indikerte at spørsmålet var høysensitivt, mens en score på 4 indikerte at det var ikke-sensitivt.</r:Content>
+                            </r:Abstract>
+                            <r:UniverseReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>7fc27ed5-9094-4181-9717-cb228812f326</r:ID>
+                                <r:Version>2</r:Version>
+                                <r:TypeOfObject>Universe</r:TypeOfObject>
+                            </r:UniverseReference>
+                            <r:FundingInformation>
+                                <r:AgencyOrganizationReference>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>9e2509c2-bc20-4083-b555-f6f3d7f34bf8</r:ID>
+                                    <r:Version>3</r:Version>
+                                    <r:TypeOfObject>Organization</r:TypeOfObject>
+                                </r:AgencyOrganizationReference>
+                                <r:GrantNumber>301525</r:GrantNumber>
+                            </r:FundingInformation>
+                            <r:Coverage>
+                                <r:TopicalCoverage isUniversallyUnique="true">
+                                    <r:URN>urn:ddi:no.nsd:6d0b85bc-d090-4881-9c82-4bb1cd6c816f:16</r:URN>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>6d0b85bc-d090-4881-9c82-4bb1cd6c816f</r:ID>
+                                    <r:Version>16</r:Version>
+                                    <r:Subject controlledVocabularyID="7803963d-cc69-4cf3-89fd-dc752bb16086" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">Health.PublicHealth</r:Subject>
+                                    <r:Subject controlledVocabularyID="7803963d-cc69-4cf3-89fd-dc752bb16086" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">Health.ReproductiveHealth</r:Subject>
+                                </r:TopicalCoverage>
+                                <r:SpatialCoverage isUniversallyUnique="true">
+                                    <r:URN>urn:ddi:no.nsd:afd2b786-69f3-4876-a494-0f6ffe62c399:16</r:URN>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>afd2b786-69f3-4876-a494-0f6ffe62c399</r:ID>
+                                    <r:Version>16</r:Version>
+                                    <r:BoundingBox>
+                                        <r:WestLongitude>0</r:WestLongitude>
+                                        <r:EastLongitude>0</r:EastLongitude>
+                                        <r:SouthLatitude>0</r:SouthLatitude>
+                                        <r:NorthLatitude>0</r:NorthLatitude>
+                                    </r:BoundingBox>
+                                    <r:Description>
+                                        <r:Content xml:lang="en">Country</r:Content>
+                                        <r:Content xml:lang="no">Land</r:Content>
+                                    </r:Description>
+                                    <r:CountryCode>NP</r:CountryCode>
+                                </r:SpatialCoverage>
+                                <r:TemporalCoverage isUniversallyUnique="true">
+                                    <r:URN>urn:ddi:no.nsd:0c91610a-d5b9-4bf8-8fa2-11d90e50a9b1:16</r:URN>
+                                    <r:Agency>no.nsd</r:Agency>
+                                    <r:ID>0c91610a-d5b9-4bf8-8fa2-11d90e50a9b1</r:ID>
+                                    <r:Version>16</r:Version>
+                                    <r:ReferenceDate>
+                                        <r:StartDate>2021-12-01T00:00:00Z</r:StartDate>
+                                        <r:EndDate>2022-11-30T00:00:00Z</r:EndDate>
+                                    </r:ReferenceDate>
+                                </r:TemporalCoverage>
+                            </r:Coverage>
+                            <r:AnalysisUnit controlledVocabularyID="0bdbed9d-6e38-4158-8fff-dc7ae75ad6f1" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="1">Individual</r:AnalysisUnit>
+                            <r:KindOfData controlledVocabularyID="7a26bd9e-8af6-49d6-8028-e0b698b8ead7" controlledVocabularyAgencyName="no.nsd" controlledVocabularyVersionID="2">Numeric</r:KindOfData>
+                            <r:DataCollectionReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>c60e5fba-6b5d-4061-9dd1-792bf681c603</r:ID>
+                                <r:Version>4</r:Version>
+                                <r:TypeOfObject>DataCollection</r:TypeOfObject>
+                            </r:DataCollectionReference>
+                            <r:PhysicalInstanceReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>b26778a9-3df1-4921-82a9-572232e70858</r:ID>
+                                <r:Version>6</r:Version>
+                                <r:TypeOfObject>PhysicalInstance</r:TypeOfObject>
+                            </r:PhysicalInstanceReference>
+                            <r:PhysicalInstanceReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>cdbc4681-c503-4d4d-b25a-60e872e32fb3</r:ID>
+                                <r:Version>5</r:Version>
+                                <r:TypeOfObject>PhysicalInstance</r:TypeOfObject>
+                            </r:PhysicalInstanceReference>
+                            <r:PhysicalInstanceReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>3716ccad-f6d9-4c92-96ad-730d12bf7134</r:ID>
+                                <r:Version>5</r:Version>
+                                <r:TypeOfObject>PhysicalInstance</r:TypeOfObject>
+                            </r:PhysicalInstanceReference>
+                            <r:PhysicalInstanceReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>0194c956-b6b7-446b-8087-57e94a5249e7</r:ID>
+                                <r:Version>5</r:Version>
+                                <r:TypeOfObject>PhysicalInstance</r:TypeOfObject>
+                            </r:PhysicalInstanceReference>
+                            <r:ArchiveReference>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>5725b3ee-a8ba-4868-b59c-4fc21c5331b4</r:ID>
+                                <r:Version>3</r:Version>
+                                <r:TypeOfObject>Archive</r:TypeOfObject>
+                            </r:ArchiveReference>
+                        </StudyUnit>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <PhysicalInstance isUniversallyUnique="true" versionDate="2024-05-03T13:12:27.8426901Z" xmlns="ddi:physicalinstance:3_3">
+                            <r:URN>urn:ddi:no.nsd:0194c956-b6b7-446b-8087-57e94a5249e7:5</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>0194c956-b6b7-446b-8087-57e94a5249e7</r:ID>
+                            <r:Version>5</r:Version>
+                            <r:UserAttributePair>
+                                <r:AttributeKey>ddi31:Paths</r:AttributeKey>
+                                <r:AttributeValue>{"0":"C:\\Users\\kst109\\dev\\ADVANCE 2\\Ferdige filer\\Data 4_validation_Delphi.sav"}</r:AttributeValue>
+                            </r:UserAttributePair>
+                            <r:VersionResponsibility>SIKT\kst109</r:VersionResponsibility>
+                            <r:Citation>
+                                <r:Title>
+                                    <r:String xml:lang="en">Data 4_validation_Delphi</r:String>
+                                    <r:String xml:lang="no">Data 4_validation_Delphi</r:String>
+                                </r:Title>
+                            </r:Citation>
+                            <DataFileIdentification isMaster="false">
+                                <DataFileURI isPublic="false">file:///C:/Users/kst109/dev/ADVANCE 2/Ferdige filer/Data 4_validation_Delphi.sav</DataFileURI>
+                            </DataFileIdentification>
+                            <GrossFileStructure isUniversallyUnique="true">
+                                <r:URN>urn:ddi:no.nsd:82749bb1-9636-4943-8ac8-43548487b54f:5</r:URN>
+                                <r:Agency>no.nsd</r:Agency>
+                                <r:ID>82749bb1-9636-4943-8ac8-43548487b54f</r:ID>
+                                <r:Version>5</r:Version>
+                                <CaseQuantity>45</CaseQuantity>
+                            </GrossFileStructure>
+                        </PhysicalInstance>
+                    </Fragment>
+                    <Fragment xmlns:r="ddi:reusable:3_3" xmlns="ddi:instance:3_3">
+                        <Organization isUniversallyUnique="true" versionDate="2022-03-30T11:24:17.8935675Z" xmlns="ddi:archive:3_3">
+                            <r:URN>urn:ddi:no.nsd:9e2509c2-bc20-4083-b555-f6f3d7f34bf8:3</r:URN>
+                            <r:Agency>no.nsd</r:Agency>
+                            <r:ID>9e2509c2-bc20-4083-b555-f6f3d7f34bf8</r:ID>
+                            <r:Version>3</r:Version>
+                            <r:VersionResponsibility>SIKT\mja047</r:VersionResponsibility>
+                            <r:VersionRationale>
+                                <r:RationaleDescription>
+                                    <r:String xml:lang="no">Lagt inn navn på NFR, det hadde blitt fjernet. Er nå mismatch med published</r:String>
+                                </r:RationaleDescription>
+                            </r:VersionRationale>
+                            <OrganizationIdentification>
+                                <OrganizationName>
+                                    <r:String xml:lang="en">The Research Council of Norway</r:String>
+                                    <r:String xml:lang="no">Norges forskningsråd</r:String>
+                                </OrganizationName>
+                            </OrganizationIdentification>
+                        </Organization>
+                    </Fragment>
+                </ddi:FragmentInstance>
+            </oai:metadata>
+        </oai:record>
+    </oai:GetRecord>
+</oai:OAI-PMH>


### PR DESCRIPTION
This PR modifies the harvester to correctly parse DDI 3.x instance documentaion. It adds a sample DDI 3.x fragment document and tests to validate the correct parsing of DDI 3.x fragment documents.

To enable support of parsing references, the `XMLMapper` was extracted to an interface. A new `ResolvingXMLMapper` was created to handle cases where elements can both be directly included in a StudyUnit and referenced.

This closes cessda/cessda.cdc.versions#652.