### PR TITLE
Restart the Elasticsearch client if it shuts down due to an OOM error

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
+++ b/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
@@ -155,19 +155,16 @@ public class IndexerRunner {
         if (indexerRunning.get() && !cmmStudies.isEmpty()) {
             log.info("[{}({})] Indexing...", repo.code(), langIsoCode);
 
-            // Perform indexing and deletions
-            ingestService.bulkIndex(cmmStudies, langIsoCode);
-
             // Calculate the amount of changed studies
             var studiesUpdated = getUpdatedStudies(cmmStudies, langIsoCode);
 
             // Discover studies to delete, we do this by creating a HashSet of ids and then comparing what's in the database
-            var studyIds = new HashSet<String>();
+            var studyIds = new HashSet<String>(cmmStudies.size());
             for (var study : cmmStudies) {
                 studyIds.add(study.id());
             }
 
-            var studiesToDelete = new ArrayList<CMMStudyOfLanguage>();
+            var studiesToDelete = new ArrayList<CMMStudyOfLanguage>(cmmStudies.size());
             try {
                 for (var presentStudy : ingestService.getStudiesByRepository(repo.code(), langIsoCode)) {
                     if (!studyIds.contains(presentStudy.id())) {
@@ -184,6 +181,8 @@ public class IndexerRunner {
                 }
             }
 
+            // Perform indexing and deletions
+            ingestService.bulkIndex(cmmStudies, langIsoCode);
             ingestService.bulkDelete(studiesToDelete, langIsoCode);
 
             log.info("[{}({})] Indexing succeeded: {} studies created, {} studies deleted, {} studies updated.",

--- a/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
+++ b/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
@@ -33,13 +33,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.concurrent.CompletableFuture.runAsync;
 import static net.logstash.logback.argument.StructuredArguments.keyValue;
 import static net.logstash.logback.argument.StructuredArguments.value;
 
@@ -70,6 +67,7 @@ public class IndexerRunner {
      *
      * @throws IllegalStateException if a harvest is already running.
      */
+    @SuppressWarnings("OverlyBroadCatchBlock")
     public void executeHarvestAndIngest() {
         if (!indexerRunning.getAndSet(true)) {
 
@@ -86,19 +84,16 @@ public class IndexerRunner {
             }
 
             try (repoStream) {
-                var futures = repoStream.map(repo ->
-                        runAsync(() ->
-                            // Index the repository in an asynchronous context
-                            indexRepository(repo)
-                        ).exceptionally(e -> {
-                            // Handle exceptional completion here, this allows failures to be logged as soon as possible
-                            log.error("[{}]: Unexpected error occurred when harvesting!", value(LoggingConstants.REPO_NAME, repo.code()), e);
-                            return null;
-                        })
-                    ).toArray(CompletableFuture[]::new);
+                repoStream.forEach(repo -> {
+                    try {
+                        // Index the repository
+                        indexRepository(repo);
+                    } catch (Exception e) {
+                        // Handle exceptional completion here, this allows failures to be logged as soon as possible
+                        log.error("[{}]: Unexpected error occurred when harvesting!", value(LoggingConstants.REPO_NAME, repo.code()), e);
+                    }
+                });
 
-                // Wait until all indexing futures have completed
-                CompletableFuture.allOf(futures).join();
 
                 log.info("Indexing finished. Summary of the current state:\nTotal number of records: {}",
                     value("total_cmm_studies", ingestService.getTotalHitCount("*"))
@@ -128,8 +123,18 @@ public class IndexerRunner {
             var lang = entry.getKey();
             try {
                 indexRecords(repo, lang, entry.getValue());
+            } catch (IndexingException e) {
+                log.error("[{}({})] Indexing failed: {}: {}",
+                    value(LoggingConstants.REPO_NAME, repo.code()),
+                    value(LoggingConstants.LANG_CODE, lang),
+                    value(LoggingConstants.EXCEPTION_NAME, e.getClass().getName()),
+                    value(LoggingConstants.REASON, e.getMessage())
+                );
             } catch (ElasticsearchException e) {
-                log.error("[{}({})] Error communicating with Elasticsearch!", value(LoggingConstants.REPO_NAME, repo.code()), value(LoggingConstants.LANG_CODE, lang), e);
+                log.error("[{}({})] Error communicating with Elasticsearch!",
+                    value(LoggingConstants.REPO_NAME, repo.code()),
+                    value(LoggingConstants.LANG_CODE, lang), e
+                );
             }
         }
         log.info("[{}] Repo finished, took {} seconds",
@@ -146,12 +151,22 @@ public class IndexerRunner {
      * @param langIsoCode the language code.
      * @param cmmStudies  the studies to index.
      */
-    private void indexRecords(Repo repo, String langIsoCode, List<CMMStudyOfLanguage> cmmStudies) {
+    private void indexRecords(Repo repo, String langIsoCode, List<CMMStudyOfLanguage> cmmStudies) throws IndexingException {
         if (indexerRunning.get() && !cmmStudies.isEmpty()) {
             log.info("[{}({})] Indexing...", repo.code(), langIsoCode);
 
+            // Perform indexing and deletions
+            ingestService.bulkIndex(cmmStudies, langIsoCode);
+
+            // Calculate the amount of changed studies
+            var studiesUpdated = getUpdatedStudies(cmmStudies, langIsoCode);
+
             // Discover studies to delete, we do this by creating a HashSet of ids and then comparing what's in the database
-            var studyIds = cmmStudies.stream().map(CMMStudyOfLanguage::id).collect(Collectors.toCollection(HashSet::new));
+            var studyIds = new HashSet<String>();
+            for (var study : cmmStudies) {
+                studyIds.add(study.id());
+            }
+
             var studiesToDelete = new ArrayList<CMMStudyOfLanguage>();
             try {
                 for (var presentStudy : ingestService.getStudiesByRepository(repo.code(), langIsoCode)) {
@@ -169,28 +184,15 @@ public class IndexerRunner {
                 }
             }
 
-            // Calculate the amount of changed studies
-            var studiesUpdated = getUpdatedStudies(cmmStudies, studiesToDelete.size(), langIsoCode);
+            ingestService.bulkDelete(studiesToDelete, langIsoCode);
 
-            // Perform indexing and deletions
-            try {
-                ingestService.bulkIndex(cmmStudies, langIsoCode);
-                ingestService.bulkDelete(studiesToDelete, langIsoCode);
-                log.info("[{}({})] Indexing succeeded: {} studies created, {} studies deleted, {} studies updated.",
-                    value(LoggingConstants.REPO_NAME, repo.code()),
-                    value(LoggingConstants.LANG_CODE, langIsoCode),
-                    value("created_cmm_studies", studiesUpdated.studiesCreated),
-                    value("deleted_cmm_studies", studiesUpdated.studiesDeleted),
-                    value("updated_cmm_studies", studiesUpdated.studiesUpdated)
-                );
-            } catch (IndexingException e) {
-                log.error("[{}({})] Indexing failed: {}: {}",
-                    value(LoggingConstants.REPO_NAME, repo.code()),
-                    value(LoggingConstants.LANG_CODE, langIsoCode),
-                    value(LoggingConstants.EXCEPTION_NAME, e.getClass().getName()),
-                    value(LoggingConstants.REASON, e.getMessage())
-                );
-            }
+            log.info("[{}({})] Indexing succeeded: {} studies created, {} studies deleted, {} studies updated.",
+                value(LoggingConstants.REPO_NAME, repo.code()),
+                value(LoggingConstants.LANG_CODE, langIsoCode),
+                value("created_cmm_studies", studiesUpdated.studiesCreated),
+                value("deleted_cmm_studies", studiesToDelete.size()),
+                value("updated_cmm_studies", studiesUpdated.studiesUpdated)
+            );
         }
     }
 
@@ -201,12 +203,12 @@ public class IndexerRunner {
      * @param language   the language of the studies
      * @return a {@link UpdatedStudies} describing the amount of created, deleted and updated studies
      */
-    private UpdatedStudies getUpdatedStudies(Collection<CMMStudyOfLanguage> cmmStudies, int studiesToDelete, String language) {
+    private UpdatedStudies getUpdatedStudies(Collection<CMMStudyOfLanguage> cmmStudies, String language) {
 
         var studiesCreated = new AtomicInteger(0);
         var studiesUpdated = new AtomicInteger(0);
 
-        cmmStudies.parallelStream().forEach(localStudy -> ingestService.getStudy(localStudy.id(), language)
+        cmmStudies.forEach(localStudy -> ingestService.getStudy(localStudy.id(), language)
             .ifPresentOrElse(study -> {
                 if (!localStudy.equals(study)) {
                     // The study has been updated
@@ -218,12 +220,11 @@ public class IndexerRunner {
             )
         );
 
-        return new UpdatedStudies(studiesCreated.get(), studiesToDelete, studiesUpdated.get());
+        return new UpdatedStudies(studiesCreated.get(), studiesUpdated.get());
     }
 
     private record UpdatedStudies(
         int studiesCreated,
-        int studiesDeleted,
         int studiesUpdated
     ) {
     }

--- a/src/main/java/eu/cessda/pasc/oci/configurations/ElasticsearchConfiguration.java
+++ b/src/main/java/eu/cessda/pasc/oci/configurations/ElasticsearchConfiguration.java
@@ -27,7 +27,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
@@ -43,6 +42,7 @@ public class ElasticsearchConfiguration {
     private final int esHttpPort;
     private final String esUsername;
     private final String esPassword;
+
     private final ObjectMapper objectMapper;
 
     @Autowired
@@ -60,7 +60,6 @@ public class ElasticsearchConfiguration {
         this.objectMapper = objectMapper;
     }
 
-    @Bean
     public RestClientTransport elasticsearchTransport() {
         var esHosts = new HttpHost(esHost, esHttpPort, "http");
         final var restClientBuilder = RestClient.builder(esHosts);
@@ -78,8 +77,8 @@ public class ElasticsearchConfiguration {
         return new RestClientTransport(restClient , new JacksonJsonpMapper(objectMapper));
     }
 
-    @Bean
-    public ElasticsearchClient elasticsearchClient(RestClientTransport transport) {
+    public ElasticsearchClient elasticsearchClient() {
+        var transport = elasticsearchTransport();
         return new ElasticsearchClient(transport);
     }
 }

--- a/src/main/java/eu/cessda/pasc/oci/service/DebuggingJMXBean.java
+++ b/src/main/java/eu/cessda/pasc/oci/service/DebuggingJMXBean.java
@@ -19,8 +19,6 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.cluster.GetClusterSettingsRequest;
 import co.elastic.clients.elasticsearch.cluster.HealthRequest;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.stream.Collectors;
@@ -30,13 +28,11 @@ import java.util.stream.Collectors;
  *
  * @author moses AT doraventures DOT com
  */
-@Component
 @Slf4j
 public class DebuggingJMXBean {
 
   private final ElasticsearchClient elasticsearchClient;
 
-  @Autowired
   public DebuggingJMXBean(ElasticsearchClient elasticsearchClient) {
     this.elasticsearchClient = elasticsearchClient;
   }

--- a/src/test/java/eu/cessda/pasc/oci/configurations/ElasticsearchConfigurationTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/configurations/ElasticsearchConfigurationTest.java
@@ -36,8 +36,7 @@ public class ElasticsearchConfigurationTest {
     public void shouldCreateElasticsearchRestClient() {
         // Given
         var elasticsearchConfiguration = getElasticsearchConfiguration();
-        var transport = elasticsearchConfiguration.elasticsearchTransport();
-        var client = elasticsearchConfiguration.elasticsearchClient(transport);
+        var client = elasticsearchConfiguration.elasticsearchClient();
 
         // Then
         assertNotNull(client);

--- a/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
@@ -35,6 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -68,13 +69,17 @@ public class ESIngestServiceTestIT {
     public static final String LANGUAGE_ISO_CODE = "en";
     private static final String INDEX_NAME = INDEX_TYPE + "_" + LANGUAGE_ISO_CODE;
 
-    private final ESConfigurationProperties esConfigProp;
-    private final ElasticsearchClient elasticsearchClient;
+    @Autowired
+    private ESConfigurationProperties esConfigProp;
 
     @Autowired
-    public ESIngestServiceTestIT(ESConfigurationProperties esConfigProp, ElasticsearchConfiguration elasticsearchConfiguration) {
-        this.esConfigProp = esConfigProp;
-        this.elasticsearchClient = elasticsearchConfiguration.elasticsearchClient();
+    private ElasticsearchConfiguration elasticsearchConfiguration;
+
+    private ElasticsearchClient elasticsearchClient;
+
+    @BeforeAll
+    public void setUp() {
+        elasticsearchClient = elasticsearchConfiguration.elasticsearchClient();
     }
 
     /**

--- a/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
@@ -28,8 +28,8 @@ import co.elastic.clients.elasticsearch.core.bulk.OperationType;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
 import co.elastic.clients.elasticsearch.indices.RefreshRequest;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.cessda.pasc.oci.configurations.ESConfigurationProperties;
+import eu.cessda.pasc.oci.configurations.ElasticsearchConfiguration;
 import eu.cessda.pasc.oci.models.cmmstudy.CMMStudyOfLanguage;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
@@ -68,14 +68,14 @@ public class ESIngestServiceTestIT {
     public static final String LANGUAGE_ISO_CODE = "en";
     private static final String INDEX_NAME = INDEX_TYPE + "_" + LANGUAGE_ISO_CODE;
 
-    @Autowired
-    private ObjectMapper mapper;
+    private final ESConfigurationProperties esConfigProp;
+    private final ElasticsearchClient elasticsearchClient;
 
     @Autowired
-    private ESConfigurationProperties esConfigProp;
-
-    @Autowired
-    private ElasticsearchClient elasticsearchClient;
+    public ESIngestServiceTestIT(ESConfigurationProperties esConfigProp, ElasticsearchConfiguration elasticsearchConfiguration) {
+        this.esConfigProp = esConfigProp;
+        this.elasticsearchClient = elasticsearchConfiguration.elasticsearchClient();
+    }
 
     /**
      * Reset Elasticsearch after each test

--- a/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
@@ -34,8 +34,8 @@ import eu.cessda.pasc.oci.models.cmmstudy.CMMStudyOfLanguage;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -77,7 +77,7 @@ public class ESIngestServiceTestIT {
 
     private ElasticsearchClient elasticsearchClient;
 
-    @BeforeAll
+    @Before
     public void setUp() {
         elasticsearchClient = elasticsearchConfiguration.elasticsearchClient();
     }

--- a/src/test/java/eu/cessda/pasc/oci/service/DebuggingJMXBeanTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/service/DebuggingJMXBeanTestIT.java
@@ -15,8 +15,8 @@
  */
 package eu.cessda.pasc.oci.service;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import eu.cessda.pasc.oci.configurations.AppConfigurationProperties;
+import eu.cessda.pasc.oci.configurations.ElasticsearchConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,12 +40,12 @@ public class DebuggingJMXBeanTestIT {
     private AppConfigurationProperties appConfigurationProperties;
 
     @Autowired
-    private ElasticsearchClient elasticsearchTemplate;
+    private ElasticsearchConfiguration elasticsearchTemplate;
 
     @Test
     public void shouldPrintElasticsearchDetails() throws IOException {
         // Class under test
-        DebuggingJMXBean debuggingJMXBean = new DebuggingJMXBean(elasticsearchTemplate);
+        DebuggingJMXBean debuggingJMXBean = new DebuggingJMXBean(elasticsearchTemplate.elasticsearchClient());
         assertThat(debuggingJMXBean.printElasticSearchInfo()).startsWith("Elasticsearch Client Settings");
     }
 }


### PR DESCRIPTION
The Elasticsearch client uses the Apache HTTP client to perform HTTP requests. This runs an event loop that allocates memory and, if there is significant memory pressure, the client can stop functioning if memory cannot be allocated. This PR adds code to detect this state and restarts the Elasticsearch client automatically if it has stopped.

See https://github.com/elastic/elasticsearch/issues/42133 and https://github.com/elastic/elasticsearch/pull/57973 for more information.