### PR TITLE
#674: Copy PID, creator and URL elements without a xml:lang attribute to all languages

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -178,7 +178,7 @@ public class LanguageExtractor {
      * @param <T> the type of elements
      */
     private static <T> List<T> mergeLanguages(Map<String, List<T>> map, String lang) {
-        // Get language specific PIDs, and then language nonspecific PIDs
+        // Get language specific elements, and then language nonspecific elements
         var languageSpecificList = map.get(lang);
         var nonLanguageSpecificList = map.get(XMLMapper.EMPTY_LANGUAGE);
         if (languageSpecificList != null && nonLanguageSpecificList != null) {

--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -22,6 +22,7 @@ import eu.cessda.pasc.oci.models.cmmstudy.CMMStudy;
 import eu.cessda.pasc.oci.models.cmmstudy.CMMStudyOfLanguage;
 import eu.cessda.pasc.oci.models.cmmstudy.Country;
 import eu.cessda.pasc.oci.models.cmmstudy.Publisher;
+import eu.cessda.pasc.oci.parser.XMLMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,8 +143,8 @@ public class LanguageExtractor {
             ).toList();
         builder.studyAreaCountries(countries);
         Optional.ofNullable(cmmStudy.unitTypes()).map(map -> map.get(lang)).ifPresent(builder::unitTypes);
-        Optional.ofNullable(cmmStudy.pidStudies()).map(map -> map.get(lang)).ifPresent(builder::pidStudies);
-        Optional.ofNullable(cmmStudy.creators()).map(map -> map.get(lang)).ifPresent(builder::creators);
+        Optional.ofNullable(cmmStudy.pidStudies()).map(map -> mergeLanguages(map, lang)).ifPresent(builder::pidStudies);
+        Optional.ofNullable(cmmStudy.creators()).map(map -> mergeLanguages(map, lang)).ifPresent(builder::creators);
         Optional.ofNullable(cmmStudy.typeOfSamplingProcedures()).map(map -> map.get(lang)).ifPresent(builder::typeOfSamplingProcedures);
         Optional.ofNullable(cmmStudy.samplingProcedureFreeTexts()).map(map -> map.get(lang)).ifPresent(builder::samplingProcedureFreeTexts);
         Optional.ofNullable(cmmStudy.typeOfModeOfCollections()).map(map -> map.get(lang)).ifPresent(builder::typeOfModeOfCollections);
@@ -168,4 +169,28 @@ public class LanguageExtractor {
         return builder.build();
     }
 
+    /**
+     * Merge language specific content with all languages content.
+     *
+     * @param map a map with a list of content for each language
+     * @param lang the language to merge
+     * @return a merged list
+     * @param <T> the type of elements
+     */
+    private static <T> List<T> mergeLanguages(Map<String, List<T>> map, String lang) {
+        // Get language specific PIDs, and then language nonspecific PIDs
+        var languageSpecificList = map.get(lang);
+        var nonLanguageSpecificList = map.get(XMLMapper.EMPTY_LANGUAGE);
+        if (languageSpecificList != null && nonLanguageSpecificList != null) {
+            // Allocate a new list and copy all content
+            var combinedList = new ArrayList<T>(languageSpecificList.size() + nonLanguageSpecificList.size());
+            combinedList.addAll(languageSpecificList);
+            combinedList.addAll(nonLanguageSpecificList);
+            return combinedList;
+        } else if (languageSpecificList != null) {
+            return languageSpecificList;
+        } else {
+            return nonLanguageSpecificList;
+        }
+    }
 }

--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -149,7 +149,7 @@ public class LanguageExtractor {
         Optional.ofNullable(cmmStudy.samplingProcedureFreeTexts()).map(map -> map.get(lang)).ifPresent(builder::samplingProcedureFreeTexts);
         Optional.ofNullable(cmmStudy.typeOfModeOfCollections()).map(map -> map.get(lang)).ifPresent(builder::typeOfModeOfCollections);
         Optional.ofNullable(cmmStudy.titleStudy()).map(map -> map.get(lang)).ifPresent(builder::titleStudy);
-        Optional.ofNullable(cmmStudy.dataCollectionFreeTexts()).map(map -> map.get(lang)).ifPresent(builder::dataCollectionFreeTexts);
+        Optional.ofNullable(cmmStudy.dataCollectionFreeTexts()).map(map -> mergeLanguages(map, lang)).ifPresent(builder::dataCollectionFreeTexts);
         Optional.ofNullable(cmmStudy.dataAccessFreeTexts()).map(map -> map.get(lang)).ifPresent(builder::dataAccessFreeTexts);
         Optional.ofNullable(cmmStudy.publisher()).map(map -> map.get(lang)).ifPresent(builder::publisher);
         Optional.ofNullable(cmmStudy.universe()).map(map -> map.get(lang)).ifPresent(builder::universe);

--- a/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
+++ b/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
@@ -34,24 +34,28 @@ public class OCIApplication {
 
     private static int exitCode = 0;
 
-    private final ConsumerScheduler consumerScheduler;
-
-    public OCIApplication(ConsumerScheduler consumerScheduler) {
-        this.consumerScheduler = consumerScheduler;
-    }
-
 	public static void main(String[] args) {
         // Set settings needed for the application to work properly
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
 
-        // Start the application
-        System.exit(SpringApplication.exit(SpringApplication.run(OCIApplication.class, args), () -> exitCode));
+        // Start the application. This method returns once Runner.run() returns.
+        var applicationContext = SpringApplication.run(OCIApplication.class, args);
+
+        // Exit the Spring Boot application. The exit code will have already been set.
+        var status = SpringApplication.exit(applicationContext, () -> exitCode);
+        System.exit(status);
     }
 
     @Component
     @Profile("!test")
     @SuppressWarnings({"java:S3985", "UnusedNestedClass"})
-    private class Runner implements CommandLineRunner {
+    private static class Runner implements CommandLineRunner {
+        private final ConsumerScheduler consumerScheduler;
+
+        public Runner(ConsumerScheduler consumerScheduler) {
+            this.consumerScheduler = consumerScheduler;
+        }
+
         /**
          * Run the indexer. If an exception is thrown, the exit code of the indexer is set to -1.
          * @param args unused.

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -328,13 +328,13 @@ public class CMMStudyMapper {
      * <p>
      * For Data Collection start and end date plus the four digit Year value as Data Collection Year
      */
-    ParseResults<DataCollectionPeriod, List<DateNotParsedException>> parseDataCollectionDates(Document doc, XPaths xPaths, String defaultLangIsoCode) {
+    ParseResults<DataCollectionPeriod, List<DateNotParsedException>> parseDataCollectionDates(Document doc, XPaths xPaths) {
         var parseResults = xPaths.getDataCollectionPeriodsXPath().resolve(doc, xPaths.getNamespace());
         var mappedResults = new DataCollectionPeriod(
             parseResults.results().startDate,
             parseResults.results().dataCollectionYear,
             parseResults.results().endDate,
-            mapNullLanguage(parseResults.results().freeTexts, defaultLangIsoCode)
+            parseResults.results().freeTexts
         );
         return new ParseResults<>(mappedResults, parseResults.exceptions);
     }

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -770,7 +770,7 @@ class ParsingStrategies{
         for (var element : elementList) {
             termVocabAttributeLifecycleStrategy(element, attrNames).ifPresent(termList::add);
         }
-        return Map.of("", termList);
+        return Map.of(EMPTY_LANGUAGE, termList);
     }
 
     /**
@@ -898,7 +898,7 @@ class ParsingStrategies{
 
             // If no descriptions are present, derive the text from the TypeOfSamplingProcedure element
             if (langMap.isEmpty() && termVocabAttributes.isPresent()) {
-                mergedMap.computeIfAbsent("", k -> new ArrayList<>()).add(termVocabAttributes.get());
+                mergedMap.computeIfAbsent(EMPTY_LANGUAGE, k -> new ArrayList<>()).add(termVocabAttributes.get());
             }
         }
 

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -1046,7 +1046,7 @@ class ParsingStrategies{
         for (var element : elements) {
             var eventAttr = getAttributeValue(element, EVENT_ATTR);
             var dateAttr = getAttributeValue(element, DATE_ATTR);
-            if (dateAttr.isPresent() && eventAttr.isPresent()) {
+            if (eventAttr.isPresent() && dateAttr.isPresent()) {
                 map.putIfAbsent(eventAttr.get(), dateAttr.get());
             }
         }

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -258,7 +258,7 @@ public class RecordXMLParser {
             var defaultLangIsoCode = cmmStudyMapper.parseDefaultLanguage(metadata, repository, xPaths);
             builder.titleStudy(cmmStudyMapper.parseStudyTitle(metadata, xPaths, defaultLangIsoCode));
 
-            var parseStudyUrlResults = cmmStudyMapper.parseStudyUrl(metadata, xPaths, defaultLangIsoCode);
+            var parseStudyUrlResults = cmmStudyMapper.parseStudyUrl(metadata, xPaths);
             builder.studyUrl(parseStudyUrlResults.results());
 
             var parseDataAccessURIResults = cmmStudyMapper.parseDataAccessURI(metadata, xPaths, defaultLangIsoCode);
@@ -280,8 +280,8 @@ public class RecordXMLParser {
             }
 
             builder.abstractField(cmmStudyMapper.parseAbstract(metadata, xPaths, defaultLangIsoCode));
-            builder.pidStudies(cmmStudyMapper.parsePidStudies(metadata, xPaths, defaultLangIsoCode));
-            builder.creators(cmmStudyMapper.parseCreator(metadata, xPaths, defaultLangIsoCode));
+            builder.pidStudies(cmmStudyMapper.parsePidStudies(metadata, xPaths));
+            builder.creators(cmmStudyMapper.parseCreator(metadata, xPaths));
             builder.dataAccessFreeTexts(cmmStudyMapper.parseDataAccessFreeText(metadata, xPaths, defaultLangIsoCode));
             builder.classifications(cmmStudyMapper.parseClassifications(metadata, xPaths, defaultLangIsoCode));
             builder.keywords(cmmStudyMapper.parseKeywords(metadata, xPaths, defaultLangIsoCode));

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -297,7 +297,7 @@ public class RecordXMLParser {
             builder.samplingProcedureFreeTexts(result.terms());
             builder.typeOfModeOfCollections(cmmStudyMapper.parseTypeOfModeOfCollection(metadata, xPaths, defaultLangIsoCode));
 
-            var dataCollectionPeriodResults = cmmStudyMapper.parseDataCollectionDates(metadata, xPaths, defaultLangIsoCode);
+            var dataCollectionPeriodResults = cmmStudyMapper.parseDataCollectionDates(metadata, xPaths);
             if (!dataCollectionPeriodResults.exceptions().isEmpty()) {
                 // Parsing errors occurred, log here
                 log.warn("[{}] Some dates in study {} couldn't be parsed: {}",

--- a/src/main/java/eu/cessda/pasc/oci/parser/XMLMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XMLMapper.java
@@ -35,6 +35,8 @@ import static org.jdom2.Namespace.XML_NAMESPACE;
  * @param <T> the resulting type of the mapping function.
  */
 public interface XMLMapper<T> {
+    String EMPTY_LANGUAGE = "*";
+
     /**
      * Resolves the given context object to an instance of T.
      *
@@ -120,7 +122,7 @@ public interface XMLMapper<T> {
                 return langValue;
             }
         } else {
-            return "";
+            return EMPTY_LANGUAGE;
         }
     }
 
@@ -137,7 +139,7 @@ public interface XMLMapper<T> {
     static String parseConceptLanguageCode(Element element) {
 
         var lang = getLangOfElement(element);
-        if (lang.isEmpty()) {
+        if (lang.equals(XMLMapper.EMPTY_LANGUAGE)) {
             var concept = element.getChild("concept", element.getNamespace());
             if (concept != null) {
                 lang = getLangOfElement(concept);

--- a/src/main/java/eu/cessda/pasc/oci/parser/XMLMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XMLMapper.java
@@ -35,6 +35,9 @@ import static org.jdom2.Namespace.XML_NAMESPACE;
  * @param <T> the resulting type of the mapping function.
  */
 public interface XMLMapper<T> {
+    /**
+     * Constant representing an empty language.
+     */
     String EMPTY_LANGUAGE = "*";
 
     /**
@@ -46,7 +49,12 @@ public interface XMLMapper<T> {
      */
     T resolve(Object context, Namespace... namespace);
 
-
+    /**
+     * Gets the text content of the given XML element.
+     *
+     * @param element the element
+     * @return the text of the element, or {@code null} if the element has no text
+     */
     static String getTextContent(Element element) {
         if (element != null) {
             var elementText = element.getTextTrim();

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -21,6 +21,8 @@ import eu.cessda.pasc.oci.models.cmmstudy.*;
 import lombok.*;
 import org.jdom2.Element;
 import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathFactory;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -53,8 +55,7 @@ public final class XPaths {
     @Nullable
     private final XMLMapper<Map<String, List<String>>> dataAccessUrlXPath;
     @Nullable
-    private final XMLMapper<Map<String, List<String>>> studyURLDocDscrXPath;
-    private final XMLMapper<Map<String, List<String>>> studyURLStudyDscrXPath;
+    private final XMLMapper<Map<String, List<String>>> studyURLXPath;
     private final XMLMapper<Map<String, List<Pid>>> pidStudyXPath;
     private final XMLMapper<Map<String, List<String>>> dataRestrctnXPath;
     private final XMLMapper<CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateNotParsedException>>> dataCollectionPeriodsXPath;
@@ -108,9 +109,7 @@ public final class XPaths {
         // Study title
         .titleXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Title/r:String", parseLanguageContentOfElement(Element::getTextTrim)))
         // 'Access study' link (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLDocDscrXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
-        // URL of the study description page at the SP website (when @typeOfUserID attribute is "URLServiceProvider")
-        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:UserID", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // Study number/PID
         .pidStudyXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:InternationalIdentifier", extractMetadataObjectListForEachLang(ParsingStrategies::pidLifecycleStrategy)))
         // Creator/PI
@@ -205,8 +204,8 @@ public final class XPaths {
         return Optional.ofNullable(filenameLanguagesXPath);
     }
 
-    Optional<XMLMapper<Map<String, List<String>>>> getStudyURLDocDscrXPath() {
-        return Optional.ofNullable(studyURLDocDscrXPath);
+    Optional<XMLMapper<Map<String, List<String>>>> getStudyURLXPath() {
+        return Optional.ofNullable(studyURLXPath);
     }
 
     Optional<XMLMapper<Map<String, List<UniverseElement>>>> getUniverseXPath() {
@@ -228,9 +227,22 @@ public final class XPaths {
         // Study title (in additional languages)
         .parTitleXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
         // 'Access study' link
-        .studyURLDocDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
-        // URL of the study description page at the SP website
-        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLXPath((context, namespace) -> {
+            var docDscrExpr = XPathFactory.instance().compile("//ddi:codeBook/ddi:docDscr/ddi:citation/ddi:holdings", Filters.element(), null, namespace);
+            var docDscrElems = docDscrExpr.evaluate(context);
+            var docUriStrings = extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy).apply(docDscrElems);
+
+            var stdyDscrExpr = XPathFactory.instance().compile("//ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings", Filters.element(), null, namespace);
+            var stdyDscrElems = stdyDscrExpr.evaluate(context);
+            var studyUriStrings = extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy).apply(stdyDscrElems);
+
+            // URLs in docDscr override stdyDscr
+            var studyURLs = new HashMap<>(docUriStrings);
+            for (var uriStrings : studyUriStrings.entrySet()) {
+                studyURLs.computeIfAbsent(uriStrings.getKey(), k -> new ArrayList<>()).addAll(uriStrings.getValue());
+            }
+            return studyURLs;
+        })
         // Study number/PID
         .pidStudyXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy)))
         // Creator
@@ -288,7 +300,7 @@ public final class XPaths {
         .abstractXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/stdyInfo/abstract", parseLanguageContentOfElement(Element::getTextTrim, (a, b) -> a + "<br>" + b)))
         .titleXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/titl", parseLanguageContentOfElement(Element::getTextTrim)))
         .parTitleXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/citation/titlStmt/parTitl", parseLanguageContentOfElement(Element::getTextTrim)))
-        .studyURLStudyDscrXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/setAvail/accsPlac", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
+        .studyURLXPath(new SimpleXMLMapper<>("//ddi:codeBook/stdyDscr/dataAccs/setAvail/accsPlac", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // PID path missing for most nesstar repos. Available in FORS but:
         //  -No agency
         //  -Only element freetext value.

--- a/src/main/resources/json/schema/CMMStudy.schema.json
+++ b/src/main/resources/json/schema/CMMStudy.schema.json
@@ -83,7 +83,7 @@
       "type": "object",
       "description": "A Collection of Creators(affiliation) eg \"Ami Doe(University of DV)\". Potentially in many translated languages",
       "patternProperties": {
-        "^[a-z]{2}$": {
+        "^[a-z]{2}|\\*$": {
           "type": "array",
           "description": "A Collection of Creators(affiliation) translated in this language",
           "items": [
@@ -322,7 +322,7 @@
     "pidStudies": {
       "type": "object",
       "patternProperties": {
-        "^[a-z]{2}$": {
+        "^[a-z]{2}|\\*$": {
           "type": "array",
           "description": "An array of Persistent Identifiers for this CMMStudy in this Given iso Language code.",
           "items": [
@@ -463,7 +463,7 @@
     "studyUrl": {
       "type": "object",
       "patternProperties": {
-        "^[a-z]{2}$": {
+        "^[a-z]{2}|\\*$": {
           "type": "string",
           "description": "A CMMStudy study Url for the given language code."
         }

--- a/src/main/resources/json/schema/CMMStudy.schema.json
+++ b/src/main/resources/json/schema/CMMStudy.schema.json
@@ -162,7 +162,7 @@
       "type": "object",
       "description": "A collection of data collection FreeTexts Dates, potentially translated in multiple languages",
       "patternProperties": {
-        "^[a-z]{2}$": {
+        "^[a-z]{2}|\\*$": {
           "type": "array",
           "description": "A collection data collection FreeTexts for this given language",
           "items": [

--- a/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/RecordXMLParserTest.java
@@ -28,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,6 +39,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 /**
@@ -219,7 +221,7 @@ public class RecordXMLParserTest {
     }
 
     @Test
-    public void shouldExtractAllRequiredCMMFieldsForAGivenAUKDSRecord() throws IOException, ProcessingException, JSONException, IndexerException, URISyntaxException {
+    public void shouldExtractAllRequiredCMMFieldsForAGivenAUKDSRecord() throws IOException, ProcessingException, IndexerException, URISyntaxException {
 
         // Given
         var recordXML = ResourceHandler.getResource("xml/ddi_2_5/ddi_record_ukds_example.xml");
@@ -245,17 +247,19 @@ public class RecordXMLParserTest {
         then(result.getFirst().dataCollectionYear()).isNull();
     }
 
-    private void assertThatCmmRequiredFieldsAreExtracted(CMMStudy record) throws IOException, JSONException {
+    private void assertThatCmmRequiredFieldsAreExtracted(CMMStudy record) throws IOException {
         var expectedJson = ResourceHandler.getResource("json/ddi_record_ukds_example_extracted.json");
         final JsonNode actualTree = objectMapper.valueToTree(record);
         final JsonNode expectedTree = objectMapper.readTree(expectedJson);
 
         // CMM Model Schema required fields
-        assertEquals(expectedTree.get("abstract").toString(), actualTree.get("abstract").toString(), true);
-        assertEquals(expectedTree.get("titleStudy").toString(), actualTree.get("titleStudy").toString(), true);
-        assertEquals(expectedTree.get("studyUrl").toString(), actualTree.get("studyUrl").toString(), true);
-        then(actualTree.get("studyNumber").toString()).isEqualTo(expectedTree.get("studyNumber").toString());
-        assertEquals(expectedTree.get("publisher").toString(), actualTree.get("publisher").toString(), true);
+        assertAll(
+            () -> assertEquals("abstract", expectedTree.get("abstract").toString(), actualTree.get("abstract").toString(), true),
+            () -> assertEquals("titleStudy", expectedTree.get("titleStudy").toString(), actualTree.get("titleStudy").toString(), true),
+            () -> assertEquals("studyUrl", expectedTree.get("studyUrl").toString(), actualTree.get("studyUrl").toString(), true),
+            () -> Assertions.assertEquals(expectedTree.get("studyNumber").toString(), actualTree.get("studyNumber").toString(), "studyNumber"),
+            () -> assertEquals("publisher", expectedTree.get("publisher").toString(), actualTree.get("publisher").toString(), true)
+        );
     }
 
     @Test

--- a/src/test/resources/json/ddi_record_1683_with_codebookXmlLag.json
+++ b/src/test/resources/json/ddi_record_1683_with_codebookXmlLag.json
@@ -141,7 +141,7 @@
   },
   "publicationYear": "1982-01-01T00:00:00Z",
   "pidStudies": {
-    "zz": [
+    "*": [
       {
         "agency": "UKDA",
         "pid": "1683"
@@ -157,7 +157,7 @@
     "us"
   ],
   "creators": {
-    "zz": [
+    "*": [
       {
         "name": "Hood, C.C., University of York. Institute of Social and Economic Research"
       },

--- a/src/test/resources/json/ddi_record_ukds_example_extracted.json
+++ b/src/test/resources/json/ddi_record_ukds_example_extracted.json
@@ -417,6 +417,6 @@
   },
   "lastModified": "2018-02-09T14:36:13Z",
   "studyUrl": {
-    "en": "http://doi.org/10.5255/UKDA-SN-6684-1"
+    "*": "http://doi.org/10.5255/UKDA-SN-6684-1"
   }
 }

--- a/src/test/resources/json/synthetic_compliant_record.json
+++ b/src/test/resources/json/synthetic_compliant_record.json
@@ -1,6 +1,6 @@
 {
   "pidStudies": {
-    "en": [
+    "*": [
       {
         "agency": "UKDA",
         "pid": "2305"

--- a/src/test/resources/json/synthetic_compliant_record.json
+++ b/src/test/resources/json/synthetic_compliant_record.json
@@ -210,7 +210,7 @@
     ]
   },
   "dataCollectionFreeTexts": {
-    "en": [
+    "*": [
       {
         "dataCollectionFreeText": "End of October",
         "event": "end"

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -121,7 +121,7 @@
   },
   "lastModified": "2023-12-06T13:30:08.8725293Z",
   "pidStudies": {
-    "en": [
+    "*": [
       {
         "agency": "DOI",
         "pid": "doi:10.4232/1.0004"

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3_fragments.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3_fragments.json
@@ -65,7 +65,7 @@
   "generalDataFormats": {},
   "keywords": {},
   "pidStudies": {
-    "en": [
+    "*": [
       {
         "agency": "DOI",
         "pid": "https://doi.org/10.18712/NSD-NSD3174-V1"

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3_new_fields.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3_new_fields.json
@@ -128,7 +128,7 @@
   },
   "lastModified": "2023-12-06T13:30:08.8725293Z",
   "pidStudies": {
-    "en": [
+    "*": [
       {
         "agency": "DOI",
         "pid": "doi:10.4232/1.0004"

--- a/src/test/resources/json/synthetic_compliant_record_nesstar.json
+++ b/src/test/resources/json/synthetic_compliant_record_nesstar.json
@@ -134,7 +134,7 @@
     ]
   },
   "dataCollectionFreeTexts": {
-    "xy": [
+    "*": [
       {
         "dataCollectionFreeText": "start",
         "event": "start"

--- a/src/test/resources/json/synthetic_compliant_record_nesstar.json
+++ b/src/test/resources/json/synthetic_compliant_record_nesstar.json
@@ -1,6 +1,6 @@
 {
   "pidStudies": {
-    "xy": [
+    "*": [
       {
         "pid": "\nch.sidos.ddi.468.7773\n"
       }
@@ -102,7 +102,7 @@
     ]
   },
   "creators": {
-    "xy": [
+    "*": [
       {
         "name": "Joye, Dominique (resp.)",
         "affiliation": "Service suisse d'information et d'archivage de données pour les sciences sociales - SIDOS"
@@ -186,7 +186,7 @@
   "publicationYear": "2007",
   "lastModified": "2015-05-04T22:55:30+0000",
   "studyUrl": {
-    "xy": "http://forscenter.ch/fr/service-de-donnees-et-d-information-sur-la-recherche/"
+    "*": "http://forscenter.ch/fr/service-de-donnees-et-d-information-sur-la-recherche/"
   },
   "studyNumber": "http://fors-getdata.unil.ch:80/obj/fStudy/ch.sidos.ddi.468.7773",
   "typeOfModeOfCollections": {


### PR DESCRIPTION
Language tags are not currently required for these fields in profile. These elements tend to have content that is not language specific.

This closes https://github.com/cessda/cessda.cdc.versions/issues/674