### PR TITLE
#557: Parse Data Access as Open/Restricted according to CV values or free text mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ endpoints:
 | `preferredMetadataParam` | String | The metadata prefix used when harvesting from the OAI-PMH repository.                                                                                                                                                                        |
 | `defaultLanguage`        | String | Used to set a language on an element that doesn't have `@xml:lang` defined. Defaults to `oaiPmh.metadataParsingDefaultLang.lang` if not set. This setting is only considered if `oaiPmh.metadataParsingDefaultLang.active` is set to `true`. |
 
+### Data Access mappings
+
+Data Access is primarily read in DDI-C 2.5 from `/codeBook/stdyDscr/dataAccs/useStmt/conditions` by checking for the values in [Access Rights CV](https://wiki.surfnet.nl/display/standards/info-eu-repo#infoeurepo-AccessRights) but free text values are also supported through the use of mappings JSON. Mappings for each repository can be specified in [data_access_mappings.json](/src/main/resources/data_access_mappings.json) by which XPath to use from [XPaths.java](src/main/java/eu/cessda/pasc/oci/parser/XPaths.java) and then which free texts to map to Open / Restricted. Any new XPaths that aren't already used for Data Access for some repository will also be needed to be added as a part of `parseDataAccess` in [CMMStudyMapper.java](src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java).
+
+Repository names in mapping JSON should be the same as code set in harvesting configuration (which follows the [configuration from cessda.cdc.aggregator.deploy](https://github.com/cessda/cessda.cdc.aggregator.deploy/blob/main/charts/harvester/config/config.yaml)).
+
 ## Built With
 
 * [Maven](https://maven.apache.org/) - Dependency Management

--- a/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
+++ b/src/main/java/eu/cessda/pasc/oci/LanguageExtractor.java
@@ -119,6 +119,7 @@ public class LanguageExtractor {
             .dataCollectionPeriodStartdate(cmmStudy.dataCollectionPeriodStartdate())
             .dataCollectionPeriodEnddate(cmmStudy.dataCollectionPeriodEnddate())
             .dataCollectionYear(cmmStudy.dataCollectionYear())
+            .dataAccess(cmmStudy.dataAccess())
             .langAvailableIn(Set.copyOf(availableLanguages));
         Optional.ofNullable(cmmStudy.studyXmlSourceUrl()).ifPresent(url -> builder.studyXmlSourceUrl(url.toString()));
 

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudy.java
@@ -40,6 +40,7 @@ public record CMMStudy(
     @JsonProperty("abstract") Map<String, String> abstractField,
     @JsonProperty("classifications") Map<String, List<TermVocabAttributes>> classifications,
     @JsonProperty("creators") Map<String, List<Creator>> creators,
+    @JsonProperty("dataAccess") String dataAccess,
     @JsonProperty("dataAccessFreeTexts") Map<String, List<String>> dataAccessFreeTexts,
     @JsonProperty("dataAccessUrl") Map<String, URI> dataAccessUrl,
     @JsonProperty("dataCollectionPeriodStartdate") String dataCollectionPeriodStartdate,

--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/CMMStudyOfLanguage.java
@@ -42,6 +42,7 @@ public record CMMStudyOfLanguage(
     @JsonProperty("classifications") List<TermVocabAttributes> classifications,
     @JsonProperty("code") String code,
     @JsonProperty("creators") List<Creator> creators,
+    @JsonProperty("dataAccess") String dataAccess,
     @JsonProperty("dataAccessFreeTexts") List<String> dataAccessFreeTexts,
     @JsonProperty("dataAccessUrl") URI dataAccessUrl,
     @JsonProperty("dataCollectionPeriodStartdate") String dataCollectionPeriodStartdate,

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -15,6 +15,8 @@
  */
 package eu.cessda.pasc.oci.parser;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.cessda.pasc.oci.DateNotParsedException;
 import eu.cessda.pasc.oci.configurations.AppConfigurationProperties;
 import eu.cessda.pasc.oci.configurations.Repo;
@@ -31,12 +33,17 @@ import org.jdom2.xpath.XPathFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.util.Iterator;
+import java.util.Map;
 
 /**
  * Responsible for Mapping oai-pmh fields to a CMMStudy
@@ -326,6 +333,87 @@ public class CMMStudyMapper {
         }
 
         return new ParseResults<>(studyURLs, parsingExceptions);
+    }
+
+    /**
+     * Parses Data Access to be Open / Restricted if possible.
+     * <p>
+     * Xpath = {@link XPaths#getDataAccessXPath()}, {@link XPaths#getDataAccessAltXPath()} and {@link XPaths#getDataRestrctnXPath()}
+     * <p>
+     */
+    Optional<String> parseDataAccess(Document doc, XPaths xPaths, String defaultLangIsoCode, String repository) {
+        Optional<String> dataAccess = Optional.empty();
+        var dataAccessXPath = xPaths.getDataAccessXPath();
+        if(dataAccessXPath.isPresent()) {
+            dataAccess = dataAccessXPath.get().resolve(doc, xPaths.getNamespace());
+        }
+
+        if (dataAccess.isEmpty()) {
+            try {
+                // Load the Data Access mapping JSON file
+                ClassLoader classLoader = CMMStudyMapper.class.getClassLoader();
+                InputStream inputStream = classLoader.getResourceAsStream("data_access_mappings.json");
+
+                if (inputStream == null) {
+                    throw new FileNotFoundException("Data access mapping file not found!");
+                }
+
+                // Parse the file into a JsonNode
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode rootNode = objectMapper.readTree(inputStream);
+
+                // Check if repository can be found in mappings file
+                if (rootNode.has(repository)) {
+                    JsonNode repositoryNode = rootNode.get(repository);
+                    Iterator<Map.Entry<String, JsonNode>> xpaths = repositoryNode.fields();
+
+                    // Check XPaths specified for the repository
+                    while (xpaths.hasNext()) {
+                        // Get the key (short form of XPath) and value (values to map to Open / Restricted)
+                        Map.Entry<String, JsonNode> entry = xpaths.next();
+                        String xpathKey = entry.getKey();
+                        JsonNode xpathValue = entry.getValue();
+
+                        // Resolve the corresponding XPath
+                        Map<String, List<String>> resolvedMap = null;
+                        if ("dataRestrctnXPath".equals(xpathKey)) {
+                            var dataRestrctnXPath = xPaths.getDataRestrctnXPath();
+                            if (dataRestrctnXPath != null) {
+                                resolvedMap = mapNullLanguage(dataRestrctnXPath.resolve(doc, xPaths.getNamespace()), defaultLangIsoCode);
+                            }
+                        } else if ("dataAccessAltXPath".equals(xpathKey)) {
+                            var dataAccessAltXPath = xPaths.getDataAccessAltXPath();
+                            if (dataAccessAltXPath.isPresent()) {
+                                resolvedMap = mapNullLanguage(dataAccessAltXPath.get().resolve(doc, xPaths.getNamespace()), defaultLangIsoCode);
+                            }
+                        }
+
+                        // Check if the map has entries, and if so, iterate through the list and compare each value separately
+                        if (resolvedMap != null && !resolvedMap.isEmpty()) {
+                            for (Map.Entry<String, List<String>> resolvedEntry : resolvedMap.entrySet()) {
+                                for (String resolvedValue : resolvedEntry.getValue()) {
+                                    if (xpathValue.isArray()) {
+                                        for (JsonNode arrayElement : xpathValue) {
+                                            String content = arrayElement.get("content").asText();
+                                            String accessCategory = arrayElement.get("accessCategory").asText();
+
+                                            // Compare resolved value from XPath with the content in mapping JSON
+                                            if (resolvedValue.equals(content)) {
+                                                // Return the matched access category
+                                                return Optional.of(accessCategory);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                log.error("Cannot process Data Access mapping JSON: {}", e.toString());
+            }
+        }
+        return dataAccess;
     }
 
     /**

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -1090,4 +1090,36 @@ class ParsingStrategies{
 
         return fundingMap;
     }
+
+    /**
+     * Processes a list of {@link Element}s, returning an {@link Optional} representing the access category (Open/Restricted).
+     * Returns the first non-empty valid result, otherwise returns an empty optional.
+     *
+     * @param elements the list of {@link Element}s to parse.
+     * @return an {@link Optional<String>} with "Open", "Restricted", or empty if no valid value is found.
+     */
+    static Optional<String> dataAccessStrategy(List<Element> elements) {
+        for (Element element : elements) {
+            String value = element.getTextTrim();
+
+            // Check if the value is "openAccess", return "Open"
+            if (!value.isEmpty()) {
+                if ("openAccess".equalsIgnoreCase(value)
+                    || "info:eu-repo/semantics/openAccess".equalsIgnoreCase(value)) {
+                    return Optional.of("Open");
+                }
+
+                // Check if the value is one of the restricted types and return "Restricted"
+                if ("closedAccess".equalsIgnoreCase(value)
+                    || "embargoedAccess".equalsIgnoreCase(value)
+                    || "restrictedAccess".equalsIgnoreCase(value)
+                    || "info:eu-repo/semantics/restrictedAccess".equalsIgnoreCase(value)) {
+                    return Optional.of("Restricted");
+                }
+            }
+        }
+
+        // Return empty if no valid element was found
+        return Optional.empty();
+    }
 }

--- a/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/RecordXMLParser.java
@@ -282,6 +282,7 @@ public class RecordXMLParser {
             builder.abstractField(cmmStudyMapper.parseAbstract(metadata, xPaths, defaultLangIsoCode));
             builder.pidStudies(cmmStudyMapper.parsePidStudies(metadata, xPaths, defaultLangIsoCode));
             builder.creators(cmmStudyMapper.parseCreator(metadata, xPaths, defaultLangIsoCode));
+            cmmStudyMapper.parseDataAccess(metadata, xPaths, defaultLangIsoCode, repository.code()).ifPresent(builder::dataAccess);
             builder.dataAccessFreeTexts(cmmStudyMapper.parseDataAccessFreeText(metadata, xPaths, defaultLangIsoCode));
             builder.classifications(cmmStudyMapper.parseClassifications(metadata, xPaths, defaultLangIsoCode));
             builder.keywords(cmmStudyMapper.parseKeywords(metadata, xPaths, defaultLangIsoCode));

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -117,6 +117,8 @@ public final class XPaths {
         .pidStudyXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:InternationalIdentifier", extractMetadataObjectListForEachLang(ParsingStrategies::pidLifecycleStrategy)))
         // Creator/PI
         .creatorsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Citation/r:Creator", ParsingStrategies::creatorsStrategy))
+        // Data access open/restricted
+        .dataAccessXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/a:Archive/a:ArchiveSpecific/a:Item/a:Access/a:AccessTypeName/r:String", ParsingStrategies::dataAccessStrategy))
         // Terms of data access
         .dataRestrctnXPath(new ResolvingXMLMapper<>("//s:StudyUnit[1]/a:Archive", "//s:StudyUnit[1]/r:ArchiveReference", "//a:ArchiveSpecific/a:Item/a:Access/r:Description/r:Content", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
         // Data collection period
@@ -176,6 +178,8 @@ public final class XPaths {
         })
         // PID of Related publication
         .withRelatedPublicationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:OtherMaterialScheme/r:OtherMaterial", ParsingStrategies::relatedPublicationLifecycleStrategy))
+        // Data access open/restricted
+        .withDataAccessXPath(new SimpleXMLMapper<>("//s:StudyUnit/a:Archive/a:ArchiveSpecific/a:Item/a:Access/a:TypeOfAccess", ParsingStrategies::dataAccessStrategy))
         // Topics
         .withClassificationsXPath(new SimpleXMLMapper<>("//s:StudyUnit[1]/r:Coverage/r:TopicalCoverage/r:Subject", extractMetadataObjectListForEachLang(TERM_VOCAB_ATTR_3_3_STRATEGY)))
         // Keywords

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -50,6 +50,9 @@ public final class XPaths {
     private final XMLMapper<Map<String, String>> titleXPath;
     @Nullable
     private final XMLMapper<Map<String, String>> parTitleXPath;
+    private final XMLMapper<Optional<String>> dataAccessXPath;
+    @Nullable
+    private final XMLMapper<Map<String, List<String>>> dataAccessAltXPath;
     @Nullable
     private final XMLMapper<Map<String, List<String>>> dataAccessUrlXPath;
     @Nullable
@@ -216,6 +219,14 @@ public final class XPaths {
     Optional<XMLMapper<Map<String, List<TermVocabAttributes>>>> getGeneralDataFormatXPath() {
         return Optional.ofNullable(generalDataFormatXPath);
     }
+
+    Optional<XMLMapper<Optional<String>>> getDataAccessXPath() {
+        return Optional.ofNullable(dataAccessXPath);
+    }
+
+    Optional<XMLMapper<Map<String, List<String>>>> getDataAccessAltXPath() {
+        return Optional.ofNullable(dataAccessAltXPath);
+    }
     /**
      * XPaths needed to extract metadata from DDI 2.5 documents.
      */
@@ -235,6 +246,10 @@ public final class XPaths {
         .pidStudyXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo", extractMetadataObjectListForEachLang(ParsingStrategies::pidStrategy)))
         // Creator
         .creatorsXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty", extractMetadataObjectListForEachLang(ParsingStrategies::creatorStrategy)))
+        // Data access open/restricted
+        .dataAccessXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:conditions", ParsingStrategies::dataAccessStrategy))
+        // Data access open/restricted specPerm alternative
+        .dataAccessAltXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:specPerm", extractMetadataObjectListForEachLang(ParsingStrategies::nullableElementValueStrategy)))
         // Terms of data access
         .dataAccessUrlXPath(new SimpleXMLMapper<>("//ddi:codeBook//ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:specPerm", extractMetadataObjectListForEachLang(ParsingStrategies::uriStrategy)))
         // Terms of data access

--- a/src/main/resources/data_access_mappings.json
+++ b/src/main/resources/data_access_mappings.json
@@ -1,0 +1,90 @@
+{
+    "UniData": {
+      "dataRestrctnXPath": [
+        {
+          "content": "Data are released in according to Creative Commons – Attribution 4.0 Licence, available <a href=\"https://creativecommons.org/licenses/by/4.0/\" target=\"_blank\">here</a>.",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "ISTAT data are released in according to Creative Commons – Attribution 3.0 Licence, available <a href=\"https://creativecommons.org/licenses/by/3.0\" target=\"_blank\">here</a>. The redistribution to the third party, even in partial form, of data available to UniData members only is not allowed.",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Data are released for research purposes only and are subject to authorization. The redistribution to the third party, even in partial form, of data is not allowed. Please, contact <a href=\"mailto:unidata@unimib.it\">UniData's archive</a> in order to data access.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Data are available only for members of UniData. Data are released only for scientific purpose. User agrees not to redistribute data to the third party, even in partial form, and to quote the data source in all publications using the information showed later. Other users will need to directly contact Istat.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Data are available only to members of the Department of Sociology and Social Research of the University of Milano-Bicocca. The redistribution to the third party, even in partial form, of data is not allowed. Please, contact <a href=\"mailto:unidata@unimib.it\">UniData's archive</a> in order to data access.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Data are released for research and teaching purposes only, and the redistribution to the third party, even in partial form, of data is not allowed.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Data are available only for UniData's members. Data are released for research purposes only, and the redistribution to the third party - even in partial form - of data is not allowed. For all other users an expenses reimbursement is required. Please, contact <a href=\"mailto:unidata@unimib.it\">UniData's archive</a> directly for more information.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Banca d'Italia data are released for research purposes only. The redistribution to the third party, even in partial form, of data available to UniData members only is not allowed. User agrees to quote the data source in all publications using the information showed later, and to send the complete reference of his/her research work based on the data to studi.indagini@bancaditalia.it.",
+          "accessCategory": "Restricted"
+        }
+      ]
+    },
+    "FSD": {
+      "dataRestrctnXPath": [
+        {
+          "content": "The dataset is (A) openly available for all users without registration (CC BY 4.0).",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "The dataset is (B) available for research, teaching and study.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "The dataset is (C) available only for research including master's theses.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "The dataset is (D) available only by permission from the data depositor/creator.",
+          "accessCategory": "Restricted"
+        }
+      ]
+    },
+    "SND": {
+      "dataRestrctnXPath": [
+        {
+          "content": "Access to data through SND. Data are freely accessible.",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Access to data through SND. Data are freely accessible",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Access to data through SND. Access to data is restricted.",
+          "accessCategory": "Restricted"
+        }
+      ]
+    },
+    "UKDS": {
+      "dataAccessAltXPath": [
+        {
+          "content": "Open",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Controlled",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Safeguarded",
+          "accessCategory": "Restricted"
+        }
+      ]
+    }
+  }

--- a/src/main/resources/data_access_mappings.json
+++ b/src/main/resources/data_access_mappings.json
@@ -52,6 +52,22 @@
         {
           "content": "The dataset is (D) available only by permission from the data depositor/creator.",
           "accessCategory": "Restricted"
+        },
+        {
+          "content": "Aineisto on (A) vapaasti käytettävissä ilman rekisteröitymistä (CC BY 4.0).",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Aineisto on käytettävissä (B) tutkimukseen, opetukseen ja opiskeluun.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Aineisto on käytettävissä (C) vain tutkimukseen ja ylempiin opinnäytteisiin.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Aineisto on käytettävissä (D) vain luovuttajan luvalla.",
+          "accessCategory": "Restricted"
         }
       ]
     },
@@ -67,6 +83,18 @@
         },
         {
           "content": "Access to data through SND. Access to data is restricted.",
+          "accessCategory": "Restricted"
+        },
+        {
+          "content": "Åtkomst till data via SND. Data är fritt tillgängliga.",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Åtkomst till data via SND. Data är fritt tillgängliga",
+          "accessCategory": "Open"
+        },
+        {
+          "content": "Åtkomst till data via SND. Tillgång till data är begränsad.",
           "accessCategory": "Restricted"
         }
       ]

--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -55,6 +55,10 @@
         }
       }
     },
+    "dataAccess": {
+      "type": "keyword",
+      "ignore_above": 256
+    },
     "dataAccessFreeTexts": {
       "type": "text",
       "analyzer": "pasc_standard_analyzer",

--- a/src/main/resources/json/schema/CMMStudy.schema.json
+++ b/src/main/resources/json/schema/CMMStudy.schema.json
@@ -122,15 +122,8 @@
       "additionalProperties": false
     },
     "dataAccess": {
-      "type": "object",
-      "patternProperties": {
-        "^[a-z]{2}$": {
-          "type": "string",
-          "description": "Freetext description of possibilities to access data."
-        }
-      },
-      "additionalProperties": false,
-      "description": "An object containing Freetext description of possibilities to access data. E.g. {'en': 'via web', 'no': 'Et via web'}."
+      "type": "string",
+      "description": "Data Access as Open/Restricted, either according to CV values or mapped from free text values."
     },
     "dataAccessFreeTexts": {
       "type": "object",

--- a/src/test/java/eu/cessda/pasc/oci/mock/data/ReposTestData.java
+++ b/src/test/java/eu/cessda/pasc/oci/mock/data/ReposTestData.java
@@ -74,15 +74,19 @@ public class ReposTestData
     }
 
     public static Repo getFSDRepo() {
-        return new Repo(
-            URI.create("http://services.fsd.uta.fi/v0/oai"),
-            null,
-            "FSD",
-            null,
-            "oai_ddi25",
-            null,
-            null
-        );
+        try {
+            return new Repo(
+                URI.create("http://services.fsd.uta.fi/v0/oai"),
+                Path.of(ResourceHandler.getResource("xml/ddi_2_5/").toURI()),
+                "FSD",
+                null,
+                "oai_ddi25",
+                null,
+                null
+            );
+        } catch (FileNotFoundException | URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public static Repo getNSDRepo() {

--- a/src/test/java/eu/cessda/pasc/oci/mock/data/ReposTestData.java
+++ b/src/test/java/eu/cessda/pasc/oci/mock/data/ReposTestData.java
@@ -74,19 +74,15 @@ public class ReposTestData
     }
 
     public static Repo getFSDRepo() {
-        try {
-            return new Repo(
-                URI.create("http://services.fsd.uta.fi/v0/oai"),
-                Path.of(ResourceHandler.getResource("xml/ddi_2_5/").toURI()),
-                "FSD",
-                null,
-                "oai_ddi25",
-                null,
-                null
-            );
-        } catch (FileNotFoundException | URISyntaxException e) {
-            throw new IllegalStateException(e);
-        }
+        return new Repo(
+            URI.create("http://services.fsd.uta.fi/v0/oai"),
+            null,
+            "FSD",
+            null,
+            "oai_ddi25",
+            null,
+            null
+        );
     }
 
     public static Repo getNSDRepo() {

--- a/src/test/resources/json/ddi_record_1683_with_codebookXmlLag.json
+++ b/src/test/resources/json/ddi_record_1683_with_codebookXmlLag.json
@@ -189,6 +189,7 @@
   },
   "dataCollectionPeriodStartdate": "1976-01-01T00:00:00Z",
   "dataCollectionFreeTexts": {},
+  "dataAccess": "Restricted",
   "dataAccessFreeTexts": {
     "zz": [
       "The depositor has specified that registration is required and standard conditions of use apply. The depositor may be informed about usage. See <a href=http://ukdataservice.ac.uk/get-data/how-to-access/conditions.aspx>terms and conditions of access</a> for further information."

--- a/src/test/resources/json/ddi_record_ukds_example_extracted.json
+++ b/src/test/resources/json/ddi_record_ukds_example_extracted.json
@@ -410,6 +410,7 @@
       }
     ]
   },
+  "dataAccess": "Restricted",
   "dataAccessFreeTexts": {
     "en": [
       "The depositor has specified that registration is required. Available to all registered users. The depositor may be informed about usage."

--- a/src/test/resources/json/synthetic_compliant_record.json
+++ b/src/test/resources/json/synthetic_compliant_record.json
@@ -225,6 +225,7 @@
       }
     ]
   },
+  "dataAccess": "Open",
   "dataAccessFreeTexts": {
     "fi": [
       "Restriction Text fi"

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -67,6 +67,7 @@
       }
     ]
   },
+  "dataAccess": "Open",
   "dataAccessFreeTexts": {
     "en": [
       "Data and documents are only released for academic research and teaching after the data depositor's written authorization."

--- a/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
@@ -192,6 +192,7 @@
                 <specPerm URI="http://localhost/specPerm-test-link" xml:lang="en">SpecPerm Text en</specPerm>
                 <specPerm URI="{invalid-uri}" xml:lang="en">Invalid SpecPerm Link</specPerm>
                 <specPerm xml:lang="fi">SpecPerm Text fi</specPerm>
+                <conditions elementVersion="info:eu-repo-Access-Terms vocabulary">openAccess</conditions>
               </useStmt>
               <setAvail>
                 <avlStatus xml:lang="en">AvlStatus Text en</avlStatus>

--- a/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
@@ -190,6 +190,7 @@
                                 <conditions xml:lang="en">Conditions Text en</conditions>
                                 <specPerm URI="http://localhost/specPerm-test-link" xml:lang="en">SpecPerm Text en</specPerm>
                                 <specPerm xml:lang="fi">SpecPerm Text fi</specPerm>
+                                <conditions elementVersion="info:eu-repo-Access-Terms vocabulary">openAccess</conditions>
                             </useStmt>
                             <setAvail>
                                 <avlStatus xml:lang="en">AvlStatus Text en</avlStatus>

--- a/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
+++ b/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
@@ -434,7 +434,7 @@
                         <r:ID>ZA0004_Acc</r:ID>
                         <r:Version>1.0.0</r:Version>
                         <a:AccessTypeName context="info:eu-repo-Access-Terms vocabulary">
-                            <r:String>C</r:String>
+                            <r:String>openAccess</r:String>
                         </a:AccessTypeName>
                         <r:Description>
                             <r:Content xml:lang="en">Data and documents are only released for academic research and teaching after the data depositor's written authorization.</r:Content>

--- a/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
+++ b/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
@@ -437,9 +437,9 @@
                         <r:Agency>de.gesis</r:Agency>
                         <r:ID>ZA0004_Acc</r:ID>
                         <r:Version>1.0.0</r:Version>
-                        <a:AccessTypeName context="info:eu-repo-Access-Terms vocabulary">
-                            <r:String>C</r:String>
-                        </a:AccessTypeName>
+                        <a:TypeOfAccess controlledVocabularyName="info:eu-repo-Access-Terms vocabulary">
+                            openAccess
+                        </a:TypeOfAccess>
                         <r:Description>
                             <r:Content xml:lang="en">Data and documents are only released for academic research and teaching after the data depositor's written authorization.</r:Content>
                             <r:Content xml:lang="de">Daten und Dokumente sind für die akademische Forschung und Lehre nur nach schriftlicher Genehmigung des Datengebers zugänglich.</r:Content>


### PR DESCRIPTION
CV values are checked without checking if "info:eu-repo-Access-Terms vocabulary" exists in @elementVersion / @vocabURI / @‌context / @controlledVocabularyName. It could be changed to require the correct attribute value first before checking for CV values but I think having it simpler and a bit more forgiving here is better even if the attribute is mandatory in profiles. We also allow mapping from free text values anyway so it can be thought of just allowing a free text value of e.g. "openAccess" to map to "Open" for all SPs.