### PR TITLE
#685: Add search fields for creators and funding, add normalizer to more fields and rename old ones from raw to normalized

### DIFF
--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -300,13 +300,7 @@
           "type": "text",
           "analyzer": "pasc_index_autocomplete_analyzer",
           "search_analyzer": "pasc_standard_analyzer",
-          "copy_to": "studyAreaCountriesSearchField",
-          "fields": {
-            "normalized": {
-              "type": "keyword",
-              "normalizer": "case_insensitive_normalizer"
-            }
-          }
+          "copy_to": "studyAreaCountriesSearchField"
         },
         "searchField": {
           "type": "keyword",

--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -7,7 +7,7 @@
       "search_analyzer": "pasc_standard_analyzer",
       "term_vector": "with_positions_offsets",
       "fields": {
-        "raw": {
+        "normalized": {
           "type": "keyword",
           "normalizer": "case_insensitive_normalizer"
         }
@@ -29,19 +29,22 @@
         "name": {
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
-          "term_vector": "with_positions_offsets"
+          "term_vector": "with_positions_offsets",
+          "copy_to": "creatorsSearchField"
         },
         "affiliation": {
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
-          "term_vector": "with_positions_offsets"
+          "term_vector": "with_positions_offsets",
+          "copy_to": "creatorsSearchField"
         },
         "identifier": {
           "type": "object",
           "properties": {
             "id": {
               "type": "keyword",
-              "ignore_above": 256
+              "ignore_above": 256,
+              "copy_to": "creatorsSearchField"
             },
             "type": {
               "type": "keyword",
@@ -54,6 +57,10 @@
           }
         }
       }
+    },
+    "creatorsSearchField": {
+      "type": "text",
+      "analyzer": "pasc_standard_analyzer"
     },
     "dataAccess": {
       "type": "keyword",
@@ -134,13 +141,19 @@
       "properties": {
         "agency": {
           "type": "keyword",
-          "ignore_above": 256
+          "ignore_above": 256,
+          "copy_to": "fundingSearchField"
         },
         "grantNumber": {
           "type": "keyword",
-          "ignore_above": 256
+          "ignore_above": 256,
+          "copy_to": "fundingSearchField"
         }
       }
+    },
+    "fundingSearchField": {
+      "type": "text",
+      "analyzer": "pasc_standard_analyzer"
     },
     "generalDataFormats": {
       "type": "nested",
@@ -287,7 +300,13 @@
           "type": "text",
           "analyzer": "pasc_index_autocomplete_analyzer",
           "search_analyzer": "pasc_standard_analyzer",
-          "copy_to": "studyAreaCountriesSearchField"
+          "copy_to": "studyAreaCountriesSearchField",
+          "fields": {
+            "normalized": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_normalizer"
+            }
+          }
         },
         "searchField": {
           "type": "keyword",
@@ -328,7 +347,7 @@
           "term_vector": "with_positions_offsets",
           "copy_to": [ "keywordsSearchField", "keywordsKeywordField" ],
           "fields": {
-            "raw": {
+            "normalized": {
               "type": "keyword",
               "normalizer": "case_insensitive_normalizer"
             }
@@ -366,7 +385,13 @@
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
           "term_vector": "with_positions_offsets",
-          "copy_to": "typeOfModeOfCollectionsSearchField"
+          "copy_to": "typeOfModeOfCollectionsSearchField",
+          "fields": {
+            "normalized": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_normalizer"
+            }
+          }
         },
         "vocab": {
           "type": "keyword",
@@ -420,7 +445,13 @@
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
           "term_vector": "with_positions_offsets",
-          "copy_to": "typeOfTimeMethodsSearchField"
+          "copy_to": "typeOfTimeMethodsSearchField",
+          "fields": {
+            "normalized": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_normalizer"
+            }
+          }
         },
         "vocab": {
           "type": "keyword",
@@ -450,7 +481,13 @@
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
           "term_vector": "with_positions_offsets",
-          "copy_to": "unitTypesSearchField"
+          "copy_to": "unitTypesSearchField",
+          "fields": {
+            "normalized": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_normalizer"
+            }
+          }
         },
         "vocab": {
           "type": "keyword",
@@ -481,7 +518,7 @@
           "ignore_above": 256,
           "copy_to": "classificationsSearchField",
           "fields": {
-            "raw": {
+            "normalized": {
               "type": "keyword",
               "normalizer": "case_insensitive_normalizer"
             }


### PR DESCRIPTION
I started using normalized instead of raw in coordinate-portal a long time ago because I thought raw was a bit misleading. I figured at this point it's easier to change it for CDC already while making other changes for mappings rather than changing it back to raw in coordinate-portal.

Also added normalizer to the fields that are likely to be tested as new filters (Time Method, Analysis Unit and Collection Method) just in case so the mappings don't have to be changed again soon.