### PR TITLE
Use Java 8 time APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,10 +121,6 @@
             <version>1.7.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
         </dependency>
@@ -132,11 +128,6 @@
             <groupId>com.github.java-json-tools</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>2.2.14</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
@@ -258,6 +249,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -372,7 +366,13 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!-- Release -->
             <plugin>

--- a/src/main/java/eu/cessda/pasc/oci/ConsumerScheduler.java
+++ b/src/main/java/eu/cessda/pasc/oci/ConsumerScheduler.java
@@ -74,7 +74,7 @@ public class ConsumerScheduler {
             log.info("[{}] Consume and Ingest All SPs Repos:\nEnded at: [{}]\nDuration: [{}] seconds",
                 FULL_RUN,
                 endTime,
-                value("job_duration", Duration.between(startTime, endTime).getSeconds())
+                value("job_duration", Duration.between(startTime, endTime).toSeconds())
             );
         } catch (IOException e) {
             log.error("Cannot connect to Elasticsearch: {}", e.toString());

--- a/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
+++ b/src/main/java/eu/cessda/pasc/oci/IndexerRunner.java
@@ -139,7 +139,7 @@ public class IndexerRunner {
         }
         log.info("[{}] Repo finished, took {} seconds",
             value(LoggingConstants.REPO_NAME, repo.code()),
-            value("repository_duration", Duration.between(startTime, Instant.now()).getSeconds())
+            value("repository_duration", Duration.between(startTime, Instant.now()).toSeconds())
         );
     }
 

--- a/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
+++ b/src/main/java/eu/cessda/pasc/oci/OCIApplication.java
@@ -25,8 +25,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.util.TimeZone;
-
 @EnableConfigurationProperties({AppConfigurationProperties.class, ESConfigurationProperties.class})
 @SpringBootApplication
 @Slf4j
@@ -35,9 +33,6 @@ public class OCIApplication {
     private static int exitCode = 0;
 
 	public static void main(String[] args) {
-        // Set settings needed for the application to work properly
-        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-
         // Start the application. This method returns once Runner.run() returns.
         var applicationContext = SpringApplication.run(OCIApplication.class, args);
 

--- a/src/main/java/eu/cessda/pasc/oci/elasticsearch/ESIngestService.java
+++ b/src/main/java/eu/cessda/pasc/oci/elasticsearch/ESIngestService.java
@@ -32,7 +32,6 @@ import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
 import co.elastic.clients.elasticsearch.indices.*;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.cessda.pasc.oci.DateNotParsedException;
 import eu.cessda.pasc.oci.ResourceHandler;
 import eu.cessda.pasc.oci.TimeUtility;
 import eu.cessda.pasc.oci.configurations.ESConfigurationProperties;
@@ -46,7 +45,8 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.time.LocalDateTime;
+import java.time.DateTimeException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
@@ -266,7 +266,7 @@ public class ESIngestService implements IngestService {
     }
 
     @Override
-    public Optional<LocalDateTime> getMostRecentLastModified() {
+    public Optional<LocalDate> getMostRecentLastModified() {
 
         var request = new SearchRequest.Builder().size(1).sort(
             new SortOptions.Builder().field(
@@ -293,9 +293,9 @@ public class ESIngestService implements IngestService {
         }
 
         try {
-            var localDateTime = TimeUtility.getLocalDateTime(study.lastModified());
-            return Optional.of(localDateTime.withHour(0).withMinute(0).withSecond(0).withNano(0));
-        } catch (DateNotParsedException e) {
+            var localDate = TimeUtility.getTimeFormat(study.lastModified(), LocalDate::from);
+            return Optional.of(localDate);
+        } catch (DateTimeException e) {
             log.error("[{}] lastModified field is not a valid ISO date: {}", study.id(), e.toString());
             return Optional.empty();
         }

--- a/src/main/java/eu/cessda/pasc/oci/elasticsearch/IngestService.java
+++ b/src/main/java/eu/cessda/pasc/oci/elasticsearch/IngestService.java
@@ -19,7 +19,7 @@ import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import eu.cessda.pasc.oci.models.cmmstudy.CMMStudyOfLanguage;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -92,5 +92,5 @@ public interface IngestService {
      *
      * @return LocalDateTime. The exact most recent lastModified dateTime from the cluster for the index pattern.
      */
-    Optional<LocalDateTime> getMostRecentLastModified();
+    Optional<LocalDate> getMostRecentLastModified();
 }

--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -17,7 +17,6 @@ package eu.cessda.pasc.oci.parser;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import eu.cessda.pasc.oci.DateNotParsedException;
 import eu.cessda.pasc.oci.ResourceHandler;
 import eu.cessda.pasc.oci.configurations.AppConfigurationProperties;
 import eu.cessda.pasc.oci.configurations.Repo;
@@ -39,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.stream.Collectors;
@@ -396,7 +396,7 @@ public class CMMStudyMapper {
      * <p>
      * For Data Collection start and end date plus the four digit Year value as Data Collection Year
      */
-    ParseResults<DataCollectionPeriod, List<DateNotParsedException>> parseDataCollectionDates(Document doc, XPaths xPaths) {
+    ParseResults<DataCollectionPeriod, List<DateTimeParseException>> parseDataCollectionDates(Document doc, XPaths xPaths) {
         var parseResults = xPaths.getDataCollectionPeriodsXPath().resolve(doc, xPaths.getNamespace());
         var mappedResults = new DataCollectionPeriod(
             parseResults.results().startDate,

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -15,7 +15,6 @@
  */
 package eu.cessda.pasc.oci.parser;
 
-import eu.cessda.pasc.oci.DateNotParsedException;
 import eu.cessda.pasc.oci.exception.UnsupportedXMLNamespaceException;
 import eu.cessda.pasc.oci.models.cmmstudy.*;
 import lombok.*;
@@ -25,6 +24,7 @@ import org.jdom2.filter.Filters;
 import org.jdom2.xpath.XPathFactory;
 
 import javax.annotation.Nullable;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.function.Function;
 
@@ -59,7 +59,7 @@ public final class XPaths {
     private final XMLMapper<Map<String, List<String>>> studyURLXPath;
     private final XMLMapper<Map<String, List<Pid>>> pidStudyXPath;
     private final XMLMapper<Map<String, List<String>>> dataRestrctnXPath;
-    private final XMLMapper<CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateNotParsedException>>> dataCollectionPeriodsXPath;
+    private final XMLMapper<CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateTimeParseException>>> dataCollectionPeriodsXPath;
     private final XMLMapper<Map<String, List<TermVocabAttributes>>> classificationsXPath;
     private final XMLMapper<Map<String, List<TermVocabAttributes>>> keywordsXPath;
     private final XMLMapper<Map<String, List<TermVocabAttributes>>> typeOfTimeMethodXPath;
@@ -83,7 +83,7 @@ public final class XPaths {
     private final XMLMapper<Map<String, List<TermVocabAttributes>>> generalDataFormatXPath;
     private final XMLMapper<Map<String, List<Series>>> seriesXPath;
 
-    private static final CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateNotParsedException>> EMPTY_PARSE_RESULTS = new CMMStudyMapper.ParseResults<>(
+    private static final CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateTimeParseException>> EMPTY_PARSE_RESULTS = new CMMStudyMapper.ParseResults<>(
         new CMMStudyMapper.DataCollectionPeriod(null, 0, null, Collections.emptyMap()),
         Collections.emptyList()
     );

--- a/src/test/java/eu/cessda/pasc/oci/TimeUtilityTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/TimeUtilityTest.java
@@ -17,7 +17,11 @@ package eu.cessda.pasc.oci;
 
 import org.junit.Test;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -33,21 +37,21 @@ public class TimeUtilityTest {
 
 
     @Test
-    public void shouldReturnExpectedDateValue() throws DateNotParsedException {
+    public void shouldReturnExpectedDateValue() {
 
         // Given
-        var localDateTime = TimeUtility.getLocalDateTime("2018-03-20");
+        var localDate = TimeUtility.getTimeFormat("2018-03-20", LocalDate::from);
 
         // When
-        then(localDateTime.toString()).isEqualToIgnoringCase("2018-03-20T00:00");
+        then(localDate.toString()).isEqualToIgnoringCase("2018-03-20");
     }
 
     // String format yyyy-MM-dd'T'HH:mm:ssZ
     @Test
-    public void shouldReturnExpectedDateValueForNesstarDateFormats() throws DateNotParsedException {
+    public void shouldReturnExpectedDateValueForNesstarDateFormats() {
 
         // Given
-        var localDateTime = TimeUtility.getLocalDateTime("2015-05-04T22:55:30+0000");
+        var localDateTime = TimeUtility.getTimeFormat("2015-05-04T22:55:30+0000", LocalDateTime::from);
 
         // When
         then(localDateTime.toString()).isEqualToIgnoringCase("2015-05-04T22:55:30");
@@ -61,11 +65,10 @@ public class TimeUtilityTest {
 
       // Then
       try {
-          TimeUtility.getLocalDateTime(invalid);
-          fail(DateNotParsedException.class.getName() + " is expected to throw");
-      } catch (DateNotParsedException e) {
-          then(e.getDateString()).isEqualTo(invalid);
-          then(e.getExpectedDateFormats()).isNotEmpty();
+          TimeUtility.getTimeFormat(invalid, Function.identity());
+          fail(DateTimeParseException.class.getName() + " is expected to throw");
+      } catch (DateTimeParseException e) {
+          then(e.getParsedString()).isEqualTo(invalid);
       }
   }
 }

--- a/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
+++ b/src/test/java/eu/cessda/pasc/oci/elasticsearch/ESIngestServiceTestIT.java
@@ -44,7 +44,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.*;
 
 import static eu.cessda.pasc.oci.mock.data.RecordTestData.getCmmStudyOfLanguageCodeEnX1;
@@ -187,10 +187,10 @@ public class ESIngestServiceTestIT {
         then(response.hits().hits().get(2).id()).isEqualTo("UK-Data-Service__1000");
 
         // When
-        Optional<LocalDateTime> mostRecentLastModified = ingestService.getMostRecentLastModified();
+        Optional<LocalDate> mostRecentLastModified = ingestService.getMostRecentLastModified();
 
         // Then
-        then(mostRecentLastModified.orElse(null)).isEqualTo(LocalDateTime.parse("2017-11-17T00:00:00"));
+        then(mostRecentLastModified.orElse(null)).isEqualTo(LocalDate.parse("2017-11-17"));
     }
 
     @Test
@@ -210,7 +210,7 @@ public class ESIngestServiceTestIT {
         elasticsearchClient.indices().refresh(RefreshRequest.of(r -> r.index(INDEX_NAME)));
 
         // When
-        Optional<LocalDateTime> mostRecentLastModified = ingestService.getMostRecentLastModified();
+        Optional<LocalDate> mostRecentLastModified = ingestService.getMostRecentLastModified();
 
         // Then
         then(mostRecentLastModified.isEmpty()).isTrue();
@@ -223,7 +223,7 @@ public class ESIngestServiceTestIT {
         var ingestService = new ESIngestService(elasticsearchClient, esConfigProp);
 
         // When
-        Optional<LocalDateTime> mostRecentLastModified = ingestService.getMostRecentLastModified();
+        Optional<LocalDate> mostRecentLastModified = ingestService.getMostRecentLastModified();
 
         // Then
         then(mostRecentLastModified.isEmpty()).isTrue();

--- a/src/test/java/eu/cessda/pasc/oci/parser/TimeUtilDateExtractionParameterisedTest.java
+++ b/src/test/java/eu/cessda/pasc/oci/parser/TimeUtilDateExtractionParameterisedTest.java
@@ -15,12 +15,12 @@
  */
 package eu.cessda.pasc.oci.parser;
 
-import eu.cessda.pasc.oci.DateNotParsedException;
 import eu.cessda.pasc.oci.TimeUtility;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.time.Year;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.TimeZone;
@@ -60,11 +60,11 @@ public class TimeUtilDateExtractionParameterisedTest {
     }
 
     @Test
-    public void shouldExtractDataCollYearDateFunction() throws DateNotParsedException {
+    public void shouldExtractDataCollYearDateFunction() {
 
         // When
-	    var localDateTime = TimeUtility.getLocalDateTime(fInput);
-	    var actualYearDate = localDateTime.getYear();
+	    var year = TimeUtility.getTimeFormat(fInput, Year::from);
+	    var actualYearDate = year.getValue();
 
         // Then
         then(actualYearDate).isEqualTo(fExpected);


### PR DESCRIPTION
Using Java 8 time APIs resolves unexpected behaviour, such as dates without timezones changing time based on the application's timezone, when the application is set to use non-UTC timezones.