### PR TITLE
#685: Add normalized field for creator name

### DIFF
--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -30,7 +30,13 @@
           "type": "text",
           "analyzer": "pasc_standard_analyzer",
           "term_vector": "with_positions_offsets",
-          "copy_to": "creatorsSearchField"
+          "copy_to": "creatorsSearchField",
+          "fields": {
+            "normalized": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_normalizer"
+            }
+          }
         },
         "affiliation": {
           "type": "text",


### PR DESCRIPTION
I think I accidentally removed this at some point when merging creator changes with index changes required for COORDINATE (currently added as runtime script in coordinate-portal so I didn't have to recreate indices and Docker image right away but I'll fix those soon also).