### PR TITLE
Remove unused HttpClient dependencies, use the Spring Boot parent POM to define the versions of Janino and Lombok

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
     </parent>
 
     <properties>
-        <buildNumber>SNAPSHOT</buildNumber>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -61,10 +60,6 @@
         <java.version>21</java.version>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <maven.compiler.source>${java.version}</maven.compiler.source>
-
-        <!-- Dependency versions -->
-        <lombok.version>1.18.36</lombok.version>
-        <elasticsearch.version>8.17.1</elasticsearch.version>
     </properties>
 
     <dependencies>
@@ -79,7 +74,6 @@
         <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
-            <version>${elasticsearch.version}</version>
         </dependency>
 
         <!-- Logging -->
@@ -327,7 +321,7 @@
                 <artifactId>elasticsearch-maven-plugin</artifactId>
                 <version>6.29</version>
                 <configuration>
-                    <version>${elasticsearch.version}</version>
+                    <version>${elasticsearch-client.version}</version>
                     <httpPort>9250</httpPort>
                     <transportPort>9350</transportPort>
                     <autoCreateIndex>false</autoCreateIndex>

--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,12 @@
         <dependency>
             <groupId>org.codehaus.janino</groupId>
             <artifactId>janino</artifactId>
-            <version>3.1.12</version>
         </dependency>
 
         <!--Utils -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -114,11 +112,6 @@
         <dependency>
             <groupId>org.jdom</groupId>
             <artifactId>jdom2</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.github.mizosoft.methanol</groupId>
-            <artifactId>methanol</artifactId>
-            <version>1.8.1</version>
         </dependency>
         <dependency>
             <groupId>jaxen</groupId>
@@ -145,12 +138,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.pgs-soft</groupId>
-            <artifactId>HttpClientMock</artifactId>
-            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -251,6 +238,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
                     <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
 
             <!-- SonarQube -->


### PR DESCRIPTION
This PR cleans up the POM for the indexer by removing unused dependencies and using the Spring Boot parent POM to define the versions of Janino and Lombok.