### PR TITLE
#717: Fix missing data collection ranges causing `dataCollectionYear` to be 0 rather than `null`

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/CMMStudyMapper.java
@@ -400,13 +400,7 @@ public class CMMStudyMapper {
      */
     ParseResults<DataCollectionPeriod, List<DateTimeParseException>> parseDataCollectionDates(Document doc, XPaths xPaths) {
         var parseResults = xPaths.getDataCollectionPeriodsXPath().resolve(doc, xPaths.getNamespace());
-        var mappedResults = new DataCollectionPeriod(
-            parseResults.results().startDate,
-            parseResults.results().dataCollectionYear,
-            parseResults.results().endDate,
-            parseResults.results().freeTexts
-        );
-        return new ParseResults<>(mappedResults, parseResults.exceptions);
+        return new ParseResults<>(parseResults.results, parseResults.exceptions);
     }
 
     /**

--- a/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/XPaths.java
@@ -85,7 +85,7 @@ public final class XPaths {
     private final XMLMapper<Map<String, List<Series>>> seriesXPath;
 
     private static final CMMStudyMapper.ParseResults<CMMStudyMapper.DataCollectionPeriod, List<DateTimeParseException>> EMPTY_PARSE_RESULTS = new CMMStudyMapper.ParseResults<>(
-        new CMMStudyMapper.DataCollectionPeriod(null, 0, null, Collections.emptyMap()),
+        new CMMStudyMapper.DataCollectionPeriod(null, null, null, Collections.emptyMap()),
         Collections.emptyList()
     );
 


### PR DESCRIPTION
This closes https://github.com/cessda/cessda.cdc.versions/issues/717