### PR TITLE
#660: Parse publication date of related publications, check TypeOfMaterial when parsing publications in DDI-L

### DIFF
--- a/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/RelatedPublication.java
+++ b/src/main/java/eu/cessda/pasc/oci/models/cmmstudy/RelatedPublication.java
@@ -25,9 +25,11 @@ import java.util.List;
  *
  * @param title    The title of the related publication.
  * @param holdings The URI of the holdings of the related publication.
+ * @param publicationDate The publication date of the related publication.
  */
 public record RelatedPublication(
     @JsonProperty("title") String title,
-    @JsonProperty("holdings") List<URI> holdings
+    @JsonProperty("holdings") List<URI> holdings,
+    @JsonProperty("publicationDate") String publicationDate
 ) {
 }

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -346,16 +346,15 @@ class ParsingStrategies{
             .map(d -> d.getChild("distDate", namespace))
             .map(e -> e.getAttributeValue("date"))
             .map(String::trim)
-            .orElse("");
-
-            if (!dateStr.isBlank()) {
+            .flatMap(dateStr -> {
                 try {
                     TimeUtility.getTimeFormat(dateStr, Function.identity());
-                    publicationDate = dateStr;
+                    return Optional.of(dateStr);
                 } catch (DateTimeParseException e) {
                     // Invalid date, ignore
+                    return Optional.empty();
                 }
-            }
+            }).orElse("");
         }
 
         // Try to extract text from the relPubl element

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -304,8 +304,9 @@ class ParsingStrategies{
     /**
      * Constructs a {@link RelatedPublication} using the given element.
      * <p>
-     * The strategy tries to extract the title from {@code //citation/titlStmt/titl} and the holdings from
-     * {@code //citation/holdings} using the URI attribute. If the {@code titl} element cannot be found, or if the
+     * The strategy tries to extract the title from {@code //citation/titlStmt/titl}, the holdings from
+     * {@code //citation/holdings} using the URI attribute and the publication date from
+     * {@code //citation/distStmt/distDate/@date}. If the {@code titl} element cannot be found, or if the
      * {@code titl} element is blank then the method attempts to extract directly from the element.
      * If a title cannot be extracted, an empty {@link Optional} is returned.
      * @param element the {@link Element} to parse.
@@ -317,6 +318,7 @@ class ParsingStrategies{
         // Result variables
         String title = null;
         var holdings = new ArrayList<URI>();
+        String publicationDate = "";
 
         // Determine whether the element has a citation in it
         var citation = ofNullable(element.getChild("citation", namespace));
@@ -333,10 +335,27 @@ class ParsingStrategies{
                 }
             }).ifPresent(holdings::add);
 
-        // Parse the holdings in the citation if present
+        // Parse the holdings and publication date in the citation if present
         if (citation.isPresent()) {
             var uris = parseHoldingsURI(citation.orElseThrow());
             holdings.addAll(uris);
+
+            // Parse the publication date from citation/distStmt/distDate/@date
+            var dateStr = citation
+            .map(c -> c.getChild("distStmt", namespace))
+            .map(d -> d.getChild("distDate", namespace))
+            .map(e -> e.getAttributeValue("date"))
+            .map(String::trim)
+            .orElse("");
+
+            if (!dateStr.isBlank()) {
+                try {
+                    TimeUtility.getTimeFormat(dateStr, Function.identity());
+                    publicationDate = dateStr;
+                } catch (DateTimeParseException e) {
+                    // Invalid date, ignore
+                }
+            }
         }
 
         // Try to extract text from the relPubl element
@@ -366,7 +385,7 @@ class ParsingStrategies{
 
         // Only return if the title is set
         if (title != null) {
-            var relatedPublication = new RelatedPublication(title, holdings);
+            var relatedPublication = new RelatedPublication(title, holdings, publicationDate);
             return Optional.of(relatedPublication);
         } else {
             return Optional.empty();
@@ -920,8 +939,25 @@ class ParsingStrategies{
 
         for (var element : elementList) {
 
+            // Filter by TypeOfMaterial = "Related Publication"
+            var typeOfMaterial = element.getChildTextTrim("TypeOfMaterial", null);
+            if (typeOfMaterial == null || !typeOfMaterial.equalsIgnoreCase("Related Publication")) {
+                continue;
+            }
+
             var uriList = new ArrayList<URI>();
             var titleMap = new HashMap<String, String>();
+            String publicationDate = "";
+
+            // First try ExternalURLReference as primary URI
+            var externalUrl = element.getChildTextTrim("ExternalURLReference", null);
+            if (externalUrl != null && !externalUrl.isBlank()) {
+                try {
+                    uriList.add(URI.create(externalUrl));
+                } catch (IllegalArgumentException e) {
+                    // Invalid URI, ignore
+                }
+            }
 
             // Extract the citation
             var citation = element.getChild("Citation", null);
@@ -930,20 +966,43 @@ class ParsingStrategies{
                     if (child.getName().equals("InternationalIdentifier")) {
                         // Extract the URL of the identifier
                         var identifierContext = child.getChild("IdentifierContent", null);
-                        uriList.add(URI.create(identifierContext.getTextTrim()));
+                        if (identifierContext != null) {
+                            var uriStr = identifierContext.getTextTrim();
+                            try {
+                                uriList.add(URI.create(uriStr));
+                            } catch (IllegalArgumentException e) {
+                                // Invalid URI, ignore
+                            }
+                        }
 
                     } else if (child.getName().equals("Title")) {
                         // Extract the language-dependent title
                         for (var string : child.getChildren(STRING, null)) {
                             titleMap.put(getLangOfElement(string), string.getTextTrim());
                         }
+
+                    } else if (child.getName().equals("PublicationDate")) {
+                        // Try to extract and validate SimpleDate
+                        var simpleDate = child.getChild("SimpleDate", null);
+                        if (simpleDate != null) {
+                            var dateStr = simpleDate.getTextTrim();
+                            if (!dateStr.isBlank()) {
+                                try {
+                                    TimeUtility.getTimeFormat(dateStr, Function.identity());
+                                    publicationDate = dateStr;
+                                } catch (DateTimeParseException e) {
+                                    // Invalid date, keep as ""
+                                }
+                            }
+                        }
                     }
                 }
             }
 
+            final String finalPublicationDate = publicationDate;
             titleMap.forEach((lang, title) -> {
-                // Merge the language dependent title with the list of URIs
-                var relPub = new RelatedPublication(title, uriList);
+                // Merge the language dependent title with the list of URIs and publication date
+                var relPub = new RelatedPublication(title, uriList, finalPublicationDate);
                 relPubLMap.computeIfAbsent(lang, k -> new ArrayList<>()).add(relPub);
             });
         }

--- a/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
+++ b/src/main/java/eu/cessda/pasc/oci/parser/ParsingStrategies.java
@@ -341,7 +341,7 @@ class ParsingStrategies{
             holdings.addAll(uris);
 
             // Parse the publication date from citation/distStmt/distDate/@date
-            var dateStr = citation
+            publicationDate = citation
             .map(c -> c.getChild("distStmt", namespace))
             .map(d -> d.getChild("distDate", namespace))
             .map(e -> e.getAttributeValue("date"))

--- a/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
+++ b/src/main/resources/elasticsearch/mappings/mappings_cmmstudy.json
@@ -567,6 +567,11 @@
           "type": "keyword",
           "ignore_above": 256,
           "copy_to": "relatedPublicationsSearchField"
+        },
+        "publicationDate": {
+          "type": "date",
+          "format": "strict_date_optional_time||epoch_millis||year_month||year",
+          "ignore_malformed": true
         }
       }
     },

--- a/src/test/resources/json/synthetic_compliant_record.json
+++ b/src/test/resources/json/synthetic_compliant_record.json
@@ -449,21 +449,24 @@
     "en": [
       {
         "title": "Speight, S. Smith, R. and Lloyd, E. with Coshall, C. (2010) Families experiencing multiple disadvantage: their use of and views on childcare provision, Research Report No. DCSF-RR191, London: Department for Children, Schools and Families/National Centre for Social Research. ISBN 978 1 84775 628 2.",
-        "holdings": []
+        "holdings": [],
+        "publicationDate": ""
       },
       {
         "title": "Arosio A. (2015). Parental divorce, cohabitation and the celebration of marriage in Italy. International Review of Sociology, 25(1), 166-179. doi:10.1080/03906701.2014.976950",
         "holdings": [
           "http://dx.doi.org/10.1080/03906701.2014.976950",
           "http://example.com/test-holding"
-        ]
+        ],
+        "publicationDate": "2015"
       },
       {
         "title": "This should be present",
         "holdings": [
           "http://example.com/test-ext-link",
           "http://dx.doi.org/10.1080/03906701.2014.976950"
-        ]
+        ],
+        "publicationDate": "2025-06-19"
       }
     ]
   },

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3.json
@@ -142,12 +142,21 @@
   "publicationYear": "1964",
   "relatedPublications": {
     "en": [{
-      "title": "ZA0004-10_q.pdf (Questionnaire)",
-      "holdings": []
-     }],
+      "title": "Synthetic Publication 1",
+      "holdings": [
+        "https://doi.org/10.4232/00000",
+        "doi:10.4232/00000"
+      ],
+      "publicationDate": "2025"
+     }
+    ],
     "de": [{
-      "title": "ZA0004-10_q.pdf (Fragebogen)",
-      "holdings": []
+      "title": "Synthetische Publikation 1",
+      "holdings": [
+        "https://doi.org/10.4232/00000",
+        "doi:10.4232/00000"
+      ],
+      "publicationDate": "2025"
     }]
   },
   "repositoryUrl": "http://dbkapps.gesis.org/dbkoai/oai.asp",

--- a/src/test/resources/json/synthetic_compliant_record_ddi_3_new_fields.json
+++ b/src/test/resources/json/synthetic_compliant_record_ddi_3_new_fields.json
@@ -149,12 +149,21 @@
   "publicationYear": "1964",
   "relatedPublications": {
     "en": [{
-      "title": "ZA0004-10_q.pdf (Questionnaire)",
-      "holdings": []
-     }],
+      "title": "Synthetic Publication 1",
+      "holdings": [
+        "https://doi.org/10.4232/00000",
+        "doi:10.4232/00000"
+      ],
+      "publicationDate": "2025"
+     }
+    ],
     "de": [{
-      "title": "ZA0004-10_q.pdf (Fragebogen)",
-      "holdings": []
+      "title": "Synthetische Publikation 1",
+      "holdings": [
+        "https://doi.org/10.4232/00000",
+        "doi:10.4232/00000"
+      ],
+      "publicationDate": "2025"
     }]
   },
   "repositoryUrl": "http://dbkapps.gesis.org/dbkoai/oai.asp",

--- a/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_compliant_cmm.xml
@@ -210,6 +210,9 @@
                         <titlStmt>
                             <titl xml:lang="en">Arosio A. (2015). Parental divorce, cohabitation and the celebration of marriage in Italy. International Review of Sociology, 25(1), 166-179. doi:10.1080/03906701.2014.976950</titl>
                         </titlStmt>
+                        <distStmt>
+                          <distDate xml:lang="en" date="2015"></distDate>
+                        </distStmt>
                         <holdings URI="http://dx.doi.org/10.1080/03906701.2014.976950" xml:lang="en"/>
                         <holdings URI="http://example.com/test-holding"/>
                     </citation>
@@ -227,6 +230,9 @@
                         <titlStmt>
                             <titl xml:lang="en">This should not be present</titl>
                         </titlStmt>
+                        <distStmt>
+                          <distDate xml:lang="en" date="2025-06-19"></distDate>
+                        </distStmt>
                         <holdings URI="http://dx.doi.org/10.1080/03906701.2014.976950" xml:lang="en"/>
                     </citation>
                     <ExtLink URI="http://example.com/test-ext-link"/>

--- a/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
+++ b/src/test/resources/xml/ddi_2_5/synthetic_list_records_response.xml
@@ -208,6 +208,9 @@
                                     <titlStmt>
                                         <titl xml:lang="en">Arosio A. (2015). Parental divorce, cohabitation and the celebration of marriage in Italy. International Review of Sociology, 25(1), 166-179. doi:10.1080/03906701.2014.976950</titl>
                                     </titlStmt>
+                                    <distStmt>
+                                        <distDate xml:lang="en" date="2015"></distDate>
+                                    </distStmt>
                                     <holdings URI="http://dx.doi.org/10.1080/03906701.2014.976950" xml:lang="en"/>
                                     <holdings URI="http://example.com/test-holding"/>
                                 </citation>
@@ -225,6 +228,9 @@
                                     <titlStmt>
                                         <titl xml:lang="en">This should not be present</titl>
                                     </titlStmt>
+                                    <distStmt>
+                                        <distDate xml:lang="en" date="2025-06-19"></distDate>
+                                    </distStmt>
                                     <holdings URI="http://dx.doi.org/10.1080/03906701.2014.976950" xml:lang="en"/>
                                 </citation>
                                 <ExtLink URI="http://example.com/test-ext-link"/>

--- a/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
+++ b/src/test/resources/xml/ddi_3_2/synthetic_compliant_cmm_ddi3_2.xml
@@ -324,6 +324,26 @@
             </r:Citation>
             <r:ExternalURLReference>https://dbk.gesis.org/dbksearch/download.asp?id=54968</r:ExternalURLReference>
         </r:OtherMaterial>
+        <r:OtherMaterial>
+            <r:Agency>de.gesis</r:Agency>
+            <r:ID>ZA0004_RelPub1</r:ID>
+            <r:Version>1.0.0</r:Version>
+            <r:TypeOfMaterial>Related Publication</r:TypeOfMaterial>
+            <r:Citation>
+                <r:Title>
+                    <r:String xml:lang="en">Synthetic Publication 1</r:String>
+                    <r:String xml:lang="de">Synthetische Publikation 1</r:String>
+                </r:Title>
+                <r:PublicationDate>
+                    <r:SimpleDate>2025</r:SimpleDate>
+                </r:PublicationDate>
+                <r:InternationalIdentifier>
+                    <r:IdentifierContent>doi:10.4232/00000</r:IdentifierContent>
+                    <r:ManagingAgency>DOI</r:ManagingAgency>
+                </r:InternationalIdentifier>
+            </r:Citation>
+            <r:ExternalURLReference>https://doi.org/10.4232/00000</r:ExternalURLReference>
+        </r:OtherMaterial>
         <c:ConceptualComponent>
             <r:Agency>de.gesis</r:Agency>
             <r:ID>ZA0004h</r:ID>

--- a/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
+++ b/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3.xml
@@ -327,6 +327,26 @@
                 </r:Citation>
                 <r:ExternalURLReference>https://dbk.gesis.org/dbksearch/download.asp?id=54968</r:ExternalURLReference>
             </r:OtherMaterial>
+            <r:OtherMaterial>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_RelPub1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:TypeOfMaterial>Related Publication</r:TypeOfMaterial>
+                <r:Citation>
+                    <r:Title>
+                        <r:String xml:lang="en">Synthetic Publication 1</r:String>
+                        <r:String xml:lang="de">Synthetische Publikation 1</r:String>
+                    </r:Title>
+                    <r:PublicationDate>
+                        <r:SimpleDate>2025</r:SimpleDate>
+                    </r:PublicationDate>
+                    <r:InternationalIdentifier>
+                        <r:IdentifierContent>doi:10.4232/00000</r:IdentifierContent>
+                        <r:ManagingAgency>DOI</r:ManagingAgency>
+                    </r:InternationalIdentifier>
+                </r:Citation>
+                <r:ExternalURLReference>https://doi.org/10.4232/00000</r:ExternalURLReference>
+            </r:OtherMaterial>
         </r:OtherMaterialScheme>
         <c:ConceptualComponent>
             <r:Agency>de.gesis</r:Agency>

--- a/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3_new_fields.xml
+++ b/src/test/resources/xml/ddi_3_3/synthetic_compliant_cmm_ddi3_3_new_fields.xml
@@ -306,6 +306,26 @@
                 </r:Citation>
                 <r:ExternalURLReference>https://dbk.gesis.org/dbksearch/download.asp?id=54968</r:ExternalURLReference>
             </r:OtherMaterial>
+            <r:OtherMaterial>
+                <r:Agency>de.gesis</r:Agency>
+                <r:ID>ZA0004_RelPub1</r:ID>
+                <r:Version>1.0.0</r:Version>
+                <r:TypeOfMaterial>Related Publication</r:TypeOfMaterial>
+                <r:Citation>
+                    <r:Title>
+                        <r:String xml:lang="en">Synthetic Publication 1</r:String>
+                        <r:String xml:lang="de">Synthetische Publikation 1</r:String>
+                    </r:Title>
+                    <r:PublicationDate>
+                        <r:SimpleDate>2025</r:SimpleDate>
+                    </r:PublicationDate>
+                    <r:InternationalIdentifier>
+                        <r:IdentifierContent>doi:10.4232/00000</r:IdentifierContent>
+                        <r:ManagingAgency>DOI</r:ManagingAgency>
+                    </r:InternationalIdentifier>
+                </r:Citation>
+                <r:ExternalURLReference>https://doi.org/10.4232/00000</r:ExternalURLReference>
+            </r:OtherMaterial>
         </r:OtherMaterialScheme>
         <c:ConceptualComponent>
             <r:Agency>de.gesis</r:Agency>


### PR DESCRIPTION
While adding publication date for related publications, I noticed that all <code>OtherMaterial</code> was being parsed as related publications in DDI-L even though not all are publications so I added a check for <code>TypeOfMaterial</code>. According to profile, related publications should have the value of <code>Related Publication</code>.